### PR TITLE
Use the CTRULIB environment variable to point to ctrulib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,8 @@ else ifeq ($(platform), ctr)
     CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
     CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
     AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
-    DEFINES += -D_3DS -DARM11 -march=armv6k -mtune=mpcore -mfloat-abi=hard -I$(DEVKITPRO)/ctrulib/libctru/include
-    CFLAGS += $(DEFINES) -Dstricmp=strcasecmp -Dstrnicmp=strncasecmp
+    DEFINES += -D_3DS -DARM11 -march=armv6k -mtune=mpcore -mfloat-abi=hard -I$(CTRULIB)/include
+    CFLAGS += $(DEFINES) -Dstricmp=strcasecmp -Dstrnicmp=strncasecmp -fcommon
     CXXFLAGS += $(CFLAGS) -std=gnu++11
     STATIC_LINKING = 1
     HAVE_OPENGL = 0


### PR DESCRIPTION
Using the CTRULIB environment, which is defined by the buildbot, makes it possible for this build to work across different versions and layouts of devkitARM.

Also added `-fcommon` so it will compile under GCC 10 (which newer devkitARM uses).

This successfully builds under both the version of devkitARM in libretro-toolchains and the newest devkitARM.