### PR TITLE
Assorted Improvements

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -1567,7 +1567,7 @@ void CL_InitLocal (void)
 //JASON this crashes out?
 }
 
-
+extern char g_save_dir[1024];
 
 /*
 ===============
@@ -1579,12 +1579,16 @@ Writes key bindings and archived cvars to config.cfg
 void CL_WriteConfiguration (void)
 {
 	FILE	*f;
-	char	path[MAX_QPATH];
+	char	path[1024];
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	if (cls.state == ca_uninitialized)
 		return;
 
-	Com_sprintf (path, sizeof(path),"%s/config.cfg",FS_Gamedir());
+	Com_sprintf (path, sizeof(path),"%s/config.cfg",savedir);
 	f = fopen (path, "w");
 	if (!f)
 	{

--- a/client/menu.c
+++ b/client/menu.c
@@ -383,8 +383,8 @@ MAIN MENU
 
 =======================================================================
 */
-#define	MAIN_ITEMS	5
-
+//#define	MAIN_ITEMS	5
+#define	MAIN_ITEMS	2
 
 void M_Main_Draw (void)
 {
@@ -396,12 +396,15 @@ void M_Main_Draw (void)
 	int totalheight = 0;
 	char litname[80];
 	float scale = SCR_GetMenuScale();
+	/* multiplayer, options and video menus
+	 * have no purpose when using the libretro
+	 * core build */
 	char *names[] =
 	{
 		"m_main_game",
-		"m_main_multiplayer",
-		"m_main_options",
-		"m_main_video",
+		//"m_main_multiplayer",
+		//"m_main_options",
+		//"m_main_video",
 		"m_main_quit",
 		0
 	};
@@ -464,23 +467,34 @@ const char *M_Main_Key (int key)
 
 		switch (m_main_cursor)
 		{
+		/* multiplayer, options and video menus
+		 * have no purpose when using the libretro
+		 * core build */
+		//case 0:
+			//M_Menu_Game_f ();
+			//break;
+
+		//case 1:
+			//M_Menu_Multiplayer_f();
+			//break;
+
+		//case 2:
+			//M_Menu_Options_f ();
+			//break;
+
+		//case 3:
+			//M_Menu_Video_f ();
+			//break;
+
+		//case 4:
+			//M_Menu_Quit_f ();
+			//break;
+
 		case 0:
 			M_Menu_Game_f ();
 			break;
 
 		case 1:
-			M_Menu_Multiplayer_f();
-			break;
-
-		case 2:
-			M_Menu_Options_f ();
-			break;
-
-		case 3:
-			M_Menu_Video_f ();
-			break;
-
-		case 4:
 			M_Menu_Quit_f ();
 			break;
 		}
@@ -2249,15 +2263,21 @@ static menuaction_s		s_loadgame_actions[MAX_SAVEGAMES];
 char		m_savestrings[MAX_SAVEGAMES][32];
 qboolean	m_savevalid[MAX_SAVEGAMES];
 
+extern char g_save_dir[1024];
+
 void Create_Savestrings (void)
 {
 	int		i;
 	FILE	*f;
 	char	name[MAX_OSPATH];
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	for (i=0 ; i<MAX_SAVEGAMES ; i++)
 	{
-		Com_sprintf (name, sizeof(name), "%s/save/save%i/server.ssv", FS_Gamedir(), i);
+		Com_sprintf (name, sizeof(name), "%s/save/save%i/server.ssv", savedir, i);
 		f = fopen (name, "rb");
 		if (!f)
 		{
@@ -4357,9 +4377,9 @@ void M_Draw (void)
 
 	// dim everything behind it down
 	if (cl.cinematictime > 0)
-		re.DrawFill (0,0,viddef.width, viddef.height, 0);
+		re.DrawFadeScreen (0);
 	else
-		re.DrawFadeScreen ();
+		re.DrawFadeScreen (1);
 
 	m_drawfunc ();
 

--- a/client/ref.h
+++ b/client/ref.h
@@ -168,7 +168,7 @@ typedef struct
 	void	(*DrawChar) (int x, int y, int c, float scale);
 	void	(*DrawTileClear) (int x, int y, int w, int h, char *name);
 	void	(*DrawFill) (int x, int y, int w, int h, int c);
-	void	(*DrawFadeScreen) (void);
+	void	(*DrawFadeScreen) (int transparent);
 
 	// Draw images for cinematic rendering (which can have a different palette). Note that calls
 	void	(*DrawStretchRaw) (int x, int y, int w, int h, int cols, int rows, byte *data);

--- a/game/player/hud.c
+++ b/game/player/hud.c
@@ -406,6 +406,8 @@ InventoryMessage(edict_t *ent)
 
 /* ======================================================================= */
 
+extern void IN_StartRumble (void);
+
 void
 G_SetStats(edict_t *ent)
 {
@@ -420,6 +422,13 @@ G_SetStats(edict_t *ent)
 
 	/* health */
 	ent->client->ps.stats[STAT_HEALTH_ICON] = level.pic_health;
+
+	/* Health is decreasing, trigger a rumble on PSTV */
+	if (ent->client->ps.stats[STAT_HEALTH] > ent->health)
+	{
+		IN_StartRumble();
+	}
+
 	ent->client->ps.stats[STAT_HEALTH] = ent->health;
 
 	/* ammo */

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010-2018 The RetroArch team
+/* Copyright (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this libretro API header (libretro.h).
@@ -278,6 +278,11 @@ enum retro_language
    RETRO_LANGUAGE_ARABIC              = 16,
    RETRO_LANGUAGE_GREEK               = 17,
    RETRO_LANGUAGE_TURKISH             = 18,
+   RETRO_LANGUAGE_SLOVAK              = 19,
+   RETRO_LANGUAGE_PERSIAN             = 20,
+   RETRO_LANGUAGE_HEBREW              = 21,
+   RETRO_LANGUAGE_ASTURIAN            = 22,
+   RETRO_LANGUAGE_FINNISH             = 23,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -708,6 +713,9 @@ enum retro_mod
                                             * state of rumble motors in controllers.
                                             * A strong and weak motor is supported, and they can be
                                             * controlled indepedently.
+                                            * Should be called from either retro_init() or retro_load_game().
+                                            * Should not be called from retro_set_environment().
+                                            * Returns false if rumble functionality is unavailable.
                                             */
 #define RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES 24
                                            /* uint64_t * --
@@ -1087,10 +1095,10 @@ enum retro_mod
 
 #define RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE (50 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                             /* float * --
-                                            * Float value that lets us know what target refresh rate 
+                                            * Float value that lets us know what target refresh rate
                                             * is curently in use by the frontend.
                                             *
-                                            * The core can use the returned value to set an ideal 
+                                            * The core can use the returned value to set an ideal
                                             * refresh rate/framerate.
                                             */
 
@@ -1098,7 +1106,7 @@ enum retro_mod
                                             /* bool * --
                                             * Boolean value that indicates whether or not the frontend supports
                                             * input bitmasks being returned by retro_input_state_t. The advantage
-                                            * of this is that retro_input_state_t has to be only called once to 
+                                            * of this is that retro_input_state_t has to be only called once to
                                             * grab all button states instead of multiple times.
                                             *
                                             * If it returns true, you can pass RETRO_DEVICE_ID_JOYPAD_MASK as 'id'
@@ -1117,12 +1125,19 @@ enum retro_mod
                                             * This may be still be done regardless of the core options
                                             * interface version.
                                             *
-                                            * If version is 1 however, core options may instead be set by
+                                            * If version is >= 1 however, core options may instead be set by
                                             * passing an array of retro_core_option_definition structs to
                                             * RETRO_ENVIRONMENT_SET_CORE_OPTIONS, or a 2D array of
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
                                             * This allows the core to additionally set option sublabel information
                                             * and/or provide localisation support.
+                                            *
+                                            * If version is >= 2, core options may instead be set by passing
+                                            * a retro_core_options_v2 struct to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * or an array of retro_core_options_v2 structs to
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL. This allows the core
+                                            * to additionally set optional core option category information
+                                            * for frontends with core option category support.
                                             */
 
 #define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
@@ -1132,8 +1147,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -1164,12 +1179,10 @@ enum retro_mod
                                             * default value is NULL, the first entry in the
                                             * retro_core_option_definition::values array is treated as the default.
                                             *
-                                            * The number of possible options should be very limited,
+                                            * The number of possible option values should be very limited,
                                             * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
                                             * i.e. it should be feasible to cycle through options
                                             * without a keyboard.
-                                            *
-                                            * First entry should be treated as a default.
                                             *
                                             * Example entry:
                                             * {
@@ -1196,9 +1209,10 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
                                             * Afterwards it may be called again for the core to communicate
@@ -1246,6 +1260,497 @@ enum retro_mod
                                             *
                                             * Note that all core option variables will be set visible by
                                             * default when calling SET_VARIABLES/SET_CORE_OPTIONS.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER 56
+                                           /* unsigned * --
+                                            *
+                                            * Allows an implementation to ask frontend preferred hardware
+                                            * context to use. Core should use this information to deal
+                                            * with what specific context to request with SET_HW_RENDER.
+                                            *
+                                            * 'data' points to an unsigned variable
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION 57
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the disk control
+                                            * interface supported by the frontend. If callback return false,
+                                            * API version is assumed to be 0.
+                                            *
+                                            * In legacy code, the disk control interface is defined by passing
+                                            * a struct of type retro_disk_control_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+                                            * This may be still be done regardless of the disk control
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, the disk control interface may
+                                            * instead be defined by passing a struct of type
+                                            * retro_disk_control_ext_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
+                                            * This allows the core to provide additional information about
+                                            * disk images to the frontend and/or enables extra
+                                            * disk control functionality by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE 58
+                                           /* const struct retro_disk_control_ext_callback * --
+                                            * Sets an interface which frontend can use to eject and insert
+                                            * disk images, and also obtain information about individual
+                                            * disk image files registered by the core.
+                                            * This is used for games which consist of multiple images and
+                                            * must be manually swapped out by the user (e.g. PSX, floppy disk
+                                            * based systems).
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION 59
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the message
+                                            * interface supported by the frontend. If callback returns
+                                            * false, API version is assumed to be 0.
+                                            *
+                                            * In legacy code, messages may be displayed in an
+                                            * implementation-specific manner by passing a struct
+                                            * of type retro_message to RETRO_ENVIRONMENT_SET_MESSAGE.
+                                            * This may be still be done regardless of the message
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, messages may instead be
+                                            * displayed by passing a struct of type retro_message_ext
+                                            * to RETRO_ENVIRONMENT_SET_MESSAGE_EXT. This allows the
+                                            * core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MESSAGE_EXT 60
+                                           /* const struct retro_message_ext * --
+                                            * Sets a message to be displayed in an implementation-specific
+                                            * manner for a certain amount of 'frames'. Additionally allows
+                                            * the core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            * Should not be used for trivial messages, which should simply be
+                                            * logged via RETRO_ENVIRONMENT_GET_LOG_INTERFACE (or as a
+                                            * fallback, stderr).
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS 61
+                                           /* unsigned * --
+                                            * Unsigned value is the number of active input devices
+                                            * provided by the frontend. This may change between
+                                            * frames, but will remain constant for the duration
+                                            * of each frame.
+                                            * If callback returns true, a core need not poll any
+                                            * input device with an index greater than or equal to
+                                            * the number of active devices.
+                                            * If callback returns false, the number of active input
+                                            * devices is unknown. In this case, all input devices
+                                            * should be considered active.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK 62
+                                           /* const struct retro_audio_buffer_status_callback * --
+                                            * Lets the core know the occupancy level of the frontend
+                                            * audio buffer. Can be used by a core to attempt frame
+                                            * skipping in order to avoid buffer under-runs.
+                                            * A core may pass NULL to disable buffer status reporting
+                                            * in the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY 63
+                                           /* const unsigned * --
+                                            * Sets minimum frontend audio latency in milliseconds.
+                                            * Resultant audio latency may be larger than set value,
+                                            * or smaller if a hardware limit is encountered. A frontend
+                                            * is expected to honour requests up to 512 ms.
+                                            *
+                                            * - If value is less than current frontend
+                                            *   audio latency, callback has no effect
+                                            * - If value is zero, default frontend audio
+                                            *   latency is set
+                                            *
+                                            * May be used by a core to increase audio latency and
+                                            * therefore decrease the probability of buffer under-runs
+                                            * (crackling) when performing 'intensive' operations.
+                                            * A core utilising RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
+                                            * to implement audio-buffer-based frame skipping may achieve
+                                            * optimal results by setting the audio latency to a 'high'
+                                            * (typically 6x or 8x) integer multiple of the expected
+                                            * frame time.
+                                            *
+                                            * WARNING: This can only be called from within retro_run().
+                                            * Calling this can require a full reinitialization of audio
+                                            * drivers in the frontend, so it is important to call it very
+                                            * sparingly, and usually only with the users explicit consent.
+                                            * An eventual driver reinitialize will happen so that audio
+                                            * callbacks happening after this call within the same retro_run()
+                                            * call will target the newly initialized driver.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
+                                           /* const struct retro_fastforwarding_override * --
+                                            * Used by a libretro core to override the current
+                                            * fastforwarding mode of the frontend.
+                                            * If NULL is passed to this function, the frontend
+                                            * will return true if fastforwarding override
+                                            * functionality is supported (no change in
+                                            * fastforwarding state will occur in this case).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE 65
+                                           /* const struct retro_system_content_info_override * --
+                                            * Allows an implementation to override 'global' content
+                                            * info parameters reported by retro_get_system_info().
+                                            * Overrides also affect subsystem content info parameters
+                                            * set via RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO.
+                                            * This function must be called inside retro_set_environment().
+                                            * If callback returns false, content info overrides
+                                            * are unsupported by the frontend, and will be ignored.
+                                            * If callback returns true, extended game info may be
+                                            * retrieved by calling RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+                                            * in retro_load_game() or retro_load_game_special().
+                                            *
+                                            * 'data' points to an array of retro_system_content_info_override
+                                            * structs terminated by a { NULL, false, false } element.
+                                            * If 'data' is NULL, no changes will be made to the frontend;
+                                            * a core may therefore pass NULL in order to test whether
+                                            * the RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE and
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT callbacks are supported
+                                            * by the frontend.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_system_content_info_override.
+                                            *
+                                            * Example:
+                                            *
+                                            * - struct retro_system_info:
+                                            * {
+                                            *    "My Core",                      // library_name
+                                            *    "v1.0",                         // library_version
+                                            *    "m3u|md|cue|iso|chd|sms|gg|sg", // valid_extensions
+                                            *    true,                           // need_fullpath
+                                            *    false                           // block_extract
+                                            * }
+                                            *
+                                            * - Array of struct retro_system_content_info_override:
+                                            * {
+                                            *    {
+                                            *       "md|sms|gg", // extensions
+                                            *       false,       // need_fullpath
+                                            *       true         // persistent_data
+                                            *    },
+                                            *    {
+                                            *       "sg",        // extensions
+                                            *       false,       // need_fullpath
+                                            *       false        // persistent_data
+                                            *    },
+                                            *    { NULL, false, false }
+                                            * }
+                                            *
+                                            * Result:
+                                            * - Files of type m3u, cue, iso, chd will not be
+                                            *   loaded by the frontend. Frontend will pass a
+                                            *   valid path to the core, and core will handle
+                                            *   loading internally
+                                            * - Files of type md, sms, gg will be loaded by
+                                            *   the frontend. A valid memory buffer will be
+                                            *   passed to the core. This memory buffer will
+                                            *   remain valid until retro_deinit() returns
+                                            * - Files of type sg will be loaded by the frontend.
+                                            *   A valid memory buffer will be passed to the core.
+                                            *   This memory buffer will remain valid until
+                                            *   retro_load_game() (or retro_load_game_special())
+                                            *   returns
+                                            *
+                                            * NOTE: If an extension is listed multiple times in
+                                            * an array of retro_system_content_info_override
+                                            * structs, only the first instance will be registered
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_GAME_INFO_EXT 66
+                                           /* const struct retro_game_info_ext ** --
+                                            * Allows an implementation to fetch extended game
+                                            * information, providing additional content path
+                                            * and memory buffer status details.
+                                            * This function may only be called inside
+                                            * retro_load_game() or retro_load_game_special().
+                                            * If callback returns false, extended game information
+                                            * is unsupported by the frontend. In this case, only
+                                            * regular retro_game_info will be available.
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT is guaranteed
+                                            * to return true if RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+                                            * returns true.
+                                            *
+                                            * 'data' points to an array of retro_game_info_ext structs.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_game_info_ext.
+                                            *
+                                            * - If function is called inside retro_load_game(),
+                                            *   the retro_game_info_ext array is guaranteed to
+                                            *   have a size of 1 - i.e. the returned pointer may
+                                            *   be used to access directly the members of the
+                                            *   first retro_game_info_ext struct, for example:
+                                            *
+                                            *      struct retro_game_info_ext *game_info_ext;
+                                            *      if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &game_info_ext))
+                                            *         printf("Content Directory: %s\n", game_info_ext->dir);
+                                            *
+                                            * - If the function is called inside retro_load_game_special(),
+                                            *   the retro_game_info_ext array is guaranteed to have a
+                                            *   size equal to the num_info argument passed to
+                                            *   retro_load_game_special()
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 67
+                                           /* const struct retro_core_options_v2 * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * 'data' points to a retro_core_options_v2 struct, containing
+                                            * of two pointers:
+                                            * - retro_core_options_v2::categories is an array of
+                                            *   retro_core_option_v2_category structs terminated by a
+                                            *   { NULL, NULL, NULL } element. If retro_core_options_v2::categories
+                                            *   is NULL, all core options will have no category and will be shown
+                                            *   at the top level of the frontend core option interface. If frontend
+                                            *   does not have core option category support, categories array will
+                                            *   be ignored.
+                                            * - retro_core_options_v2::definitions is an array of
+                                            *   retro_core_option_v2_definition structs terminated by a
+                                            *   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL }
+                                            *   element.
+                                            *
+                                            * >> retro_core_option_v2_category notes:
+                                            *
+                                            * - retro_core_option_v2_category::key should contain string
+                                            *   that uniquely identifies the core option category. Valid
+                                            *   key characters are [a-z, A-Z, 0-9, _, -]
+                                            *   Namespace collisions with other implementations' category
+                                            *   keys are permitted.
+                                            * - retro_core_option_v2_category::desc should contain a human
+                                            *   readable description of the category key.
+                                            * - retro_core_option_v2_category::info should contain any
+                                            *   additional human readable information text that a typical
+                                            *   user may need to understand the nature of the core option
+                                            *   category.
+                                            *
+                                            * Example entry:
+                                            * {
+                                            *     "advanced_settings",
+                                            *     "Advanced",
+                                            *     "Options affecting low-level emulation performance and accuracy."
+                                            * }
+                                            *
+                                            * >> retro_core_option_v2_definition notes:
+                                            *
+                                            * - retro_core_option_v2_definition::key should be namespaced to not
+                                            *   collide with other implementations' keys. e.g. A core called
+                                            *   'foo' should use keys named as 'foo_option'. Valid key characters
+                                            *   are [a-z, A-Z, 0-9, _, -].
+                                            * - retro_core_option_v2_definition::desc should contain a human readable
+                                            *   description of the key. Will be used when the frontend does not
+                                            *   have core option category support. Examples: "Aspect Ratio" or
+                                            *   "Video > Aspect Ratio".
+                                            * - retro_core_option_v2_definition::desc_categorized should contain a
+                                            *   human readable description of the key, which will be used when
+                                            *   frontend has core option category support. Example: "Aspect Ratio",
+                                            *   where associated retro_core_option_v2_category::desc is "Video".
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::desc will be used instead.
+                                            *   retro_core_option_v2_definition::desc_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::info should contain any additional
+                                            *   human readable information text that a typical user may need to
+                                            *   understand the functionality of the option.
+                                            * - retro_core_option_v2_definition::info_categorized should contain
+                                            *   any additional human readable information text that a typical user
+                                            *   may need to understand the functionality of the option, and will be
+                                            *   used when frontend has core option category support. This is provided
+                                            *   to accommodate the case where info text references an option by
+                                            *   name/desc, and the desc/desc_categorized text for that option differ.
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::info will be used instead.
+                                            *   retro_core_option_v2_definition::info_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::category_key should contain a
+                                            *   category identifier (e.g. "video" or "audio") that will be
+                                            *   assigned to the core option if frontend has core option category
+                                            *   support. A categorized option will be shown in a subsection/
+                                            *   submenu of the frontend core option interface. If key is empty
+                                            *   or NULL, or if key does not match one of the
+                                            *   retro_core_option_v2_category::key values in the associated
+                                            *   retro_core_option_v2_category array, option will have no category
+                                            *   and will be shown at the top level of the frontend core option
+                                            *   interface.
+                                            * - retro_core_option_v2_definition::values is an array of
+                                            *   retro_core_option_value structs terminated by a { NULL, NULL }
+                                            *   element.
+                                            * --> retro_core_option_v2_definition::values[index].value is an
+                                            *     expected option value.
+                                            * --> retro_core_option_v2_definition::values[index].label is a
+                                            *     human readable label used when displaying the value on screen.
+                                            *     If NULL, the value itself is used.
+                                            * - retro_core_option_v2_definition::default_value is the default
+                                            *   core option setting. It must match one of the expected option
+                                            *   values in the retro_core_option_v2_definition::values array. If
+                                            *   it does not, or the default value is NULL, the first entry in the
+                                            *   retro_core_option_v2_definition::values array is treated as the
+                                            *   default.
+                                            *
+                                            * The number of possible option values should be very limited,
+                                            * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
+                                            * i.e. it should be feasible to cycle through options
+                                            * without a keyboard.
+                                            *
+                                            * Example entries:
+                                            *
+                                            * - Uncategorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Speed hack coprocessor X",
+                                            *     NULL,
+                                            *     "Provides increased performance at the expense of reduced accuracy.",
+                                            *     NULL,
+                                            *     NULL,
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * - Categorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Advanced > Speed hack coprocessor X",
+                                            *     "Speed hack coprocessor X",
+                                            *     "Setting 'Advanced > Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "Setting 'Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "advanced_settings",
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * Only strings are operated on. The possible values will
+                                            * generally be displayed and stored as-is by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL 68
+                                           /* const struct retro_core_options_v2_intl * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * This is fundamentally the same as RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * with the addition of localisation support. The description of the
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 callback should be consulted
+                                            * for further details.
+                                            *
+                                            * 'data' points to a retro_core_options_v2_intl struct.
+                                            *
+                                            * - retro_core_options_v2_intl::us is a pointer to a
+                                            *   retro_core_options_v2 struct defining the US English
+                                            *   core options implementation. It must point to a valid struct.
+                                            *
+                                            * - retro_core_options_v2_intl::local is a pointer to a
+                                            *   retro_core_options_v2 struct defining core options for
+                                            *   the current frontend language. It may be NULL (in which case
+                                            *   retro_core_options_v2_intl::us is used by the frontend). Any items
+                                            *   missing from this struct will be read from
+                                            *   retro_core_options_v2_intl::us instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_v2_intl::us struct. Any default values in
+                                            * the retro_core_options_v2_intl::local struct will be ignored.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK 69
+                                           /* const struct retro_core_options_update_display_callback * --
+                                            * Allows a frontend to signal that a core must update
+                                            * the visibility of any dynamically hidden core options,
+                                            * and enables the frontend to detect visibility changes.
+                                            * Used by the frontend to update the menu display status
+                                            * of core options without requiring a call of retro_run().
+                                            * Must be called in retro_set_environment().
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_VARIABLE 70
+                                           /* const struct retro_variable * --
+                                            * Allows an implementation to notify the frontend
+                                            * that a core option value has changed.
+                                            *
+                                            * retro_variable::key and retro_variable::value
+                                            * must match strings that have been set previously
+                                            * via one of the following:
+                                            *
+                                            * - RETRO_ENVIRONMENT_SET_VARIABLES
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL
+                                            *
+                                            * After changing a core option value via this
+                                            * callback, RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE
+                                            * will return true.
+                                            *
+                                            * If data is NULL, no changes will be registered
+                                            * and the callback will return true; an
+                                            * implementation may therefore pass NULL in order
+                                            * to test whether the callback is supported.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_THROTTLE_STATE (71 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_throttle_state * --
+                                            * Allows an implementation to get details on the actual rate
+                                            * the frontend is attempting to call retro_run().
                                             */
 
 /* VFS functionality */
@@ -1924,6 +2429,10 @@ enum retro_sensor_action
 {
    RETRO_SENSOR_ACCELEROMETER_ENABLE = 0,
    RETRO_SENSOR_ACCELEROMETER_DISABLE,
+   RETRO_SENSOR_GYROSCOPE_ENABLE,
+   RETRO_SENSOR_GYROSCOPE_DISABLE,
+   RETRO_SENSOR_ILLUMINANCE_ENABLE,
+   RETRO_SENSOR_ILLUMINANCE_DISABLE,
 
    RETRO_SENSOR_DUMMY = INT_MAX
 };
@@ -1932,6 +2441,10 @@ enum retro_sensor_action
 #define RETRO_SENSOR_ACCELEROMETER_X 0
 #define RETRO_SENSOR_ACCELEROMETER_Y 1
 #define RETRO_SENSOR_ACCELEROMETER_Z 2
+#define RETRO_SENSOR_GYROSCOPE_X 3
+#define RETRO_SENSOR_GYROSCOPE_Y 4
+#define RETRO_SENSOR_GYROSCOPE_Z 5
+#define RETRO_SENSOR_ILLUMINANCE 6
 
 typedef bool (RETRO_CALLCONV *retro_set_sensor_state_t)(unsigned port,
       enum retro_sensor_action action, unsigned rate);
@@ -2129,6 +2642,30 @@ struct retro_frame_time_callback
    retro_usec_t reference;
 };
 
+/* Notifies a libretro core of the current occupancy
+ * level of the frontend audio buffer.
+ *
+ * - active: 'true' if audio buffer is currently
+ *           in use. Will be 'false' if audio is
+ *           disabled in the frontend
+ *
+ * - occupancy: Given as a value in the range [0,100],
+ *              corresponding to the occupancy percentage
+ *              of the audio buffer
+ *
+ * - underrun_likely: 'true' if the frontend expects an
+ *                    audio buffer underrun during the
+ *                    next frame (indicates that a core
+ *                    should attempt frame skipping)
+ *
+ * It will be called right before retro_run() every frame. */
+typedef void (RETRO_CALLCONV *retro_audio_buffer_status_callback_t)(
+      bool active, unsigned occupancy, bool underrun_likely);
+struct retro_audio_buffer_status_callback
+{
+   retro_audio_buffer_status_callback_t callback;
+};
+
 /* Pass this to retro_video_refresh_t if rendering to hardware.
  * Passing NULL to retro_video_refresh_t is still a frame dupe as normal.
  * */
@@ -2289,7 +2826,8 @@ struct retro_keyboard_callback
    retro_keyboard_event_t callback;
 };
 
-/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE &
+ * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
  * Should be set for implementations which can swap out multiple disk
  * images in runtime.
  *
@@ -2347,6 +2885,53 @@ typedef bool (RETRO_CALLCONV *retro_replace_image_index_t)(unsigned index,
  * with replace_image_index. */
 typedef bool (RETRO_CALLCONV *retro_add_image_index_t)(void);
 
+/* Sets initial image to insert in drive when calling
+ * core_load_game().
+ * Since we cannot pass the initial index when loading
+ * content (this would require a major API change), this
+ * is set by the frontend *before* calling the core's
+ * retro_load_game()/retro_load_game_special() implementation.
+ * A core should therefore cache the index/path values and handle
+ * them inside retro_load_game()/retro_load_game_special().
+ * - If 'index' is invalid (index >= get_num_images()), the
+ *   core should ignore the set value and instead use 0
+ * - 'path' is used purely for error checking - i.e. when
+ *   content is loaded, the core should verify that the
+ *   disk specified by 'index' has the specified file path.
+ *   This is to guard against auto selecting the wrong image
+ *   if (for example) the user should modify an existing M3U
+ *   playlist. We have to let the core handle this because
+ *   set_initial_image() must be called before loading content,
+ *   i.e. the frontend cannot access image paths in advance
+ *   and thus cannot perform the error check itself.
+ *   If set path and content path do not match, the core should
+ *   ignore the set 'index' value and instead use 0
+ * Returns 'false' if index or 'path' are invalid, or core
+ * does not support this functionality
+ */
+typedef bool (RETRO_CALLCONV *retro_set_initial_image_t)(unsigned index, const char *path);
+
+/* Fetches the path of the specified disk image file.
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or path is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_path_t)(unsigned index, char *path, size_t len);
+
+/* Fetches a core-provided 'label' for the specified disk
+ * image file. In the simplest case this may be a file name
+ * (without extension), but for cores with more complex
+ * content requirements information may be provided to
+ * facilitate user disk swapping - for example, a core
+ * running floppy-disk-based content may uniquely label
+ * save disks, data disks, level disks, etc. with names
+ * corresponding to in-game disk change prompts (so the
+ * frontend can provide better user guidance than a 'dumb'
+ * disk index value).
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or label is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_label_t)(unsigned index, char *label, size_t len);
+
 struct retro_disk_control_callback
 {
    retro_set_eject_state_t set_eject_state;
@@ -2358,6 +2943,27 @@ struct retro_disk_control_callback
 
    retro_replace_image_index_t replace_image_index;
    retro_add_image_index_t add_image_index;
+};
+
+struct retro_disk_control_ext_callback
+{
+   retro_set_eject_state_t set_eject_state;
+   retro_get_eject_state_t get_eject_state;
+
+   retro_get_image_index_t get_image_index;
+   retro_set_image_index_t set_image_index;
+   retro_get_num_images_t  get_num_images;
+
+   retro_replace_image_index_t replace_image_index;
+   retro_add_image_index_t add_image_index;
+
+   /* NOTE: Frontend will only attempt to record/restore
+    * last used disk index if both set_initial_image()
+    * and get_image_path() are implemented */
+   retro_set_initial_image_t set_initial_image; /* Optional - may be NULL */
+
+   retro_get_image_path_t get_image_path;       /* Optional - may be NULL */
+   retro_get_image_label_t get_image_label;     /* Optional - may be NULL */
 };
 
 enum retro_pixel_format
@@ -2390,6 +2996,104 @@ struct retro_message
    unsigned    frames;     /* Duration in frames of message. */
 };
 
+enum retro_message_target
+{
+   RETRO_MESSAGE_TARGET_ALL = 0,
+   RETRO_MESSAGE_TARGET_OSD,
+   RETRO_MESSAGE_TARGET_LOG
+};
+
+enum retro_message_type
+{
+   RETRO_MESSAGE_TYPE_NOTIFICATION = 0,
+   RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+   RETRO_MESSAGE_TYPE_STATUS,
+   RETRO_MESSAGE_TYPE_PROGRESS
+};
+
+struct retro_message_ext
+{
+   /* Message string to be displayed/logged */
+   const char *msg;
+   /* Duration (in ms) of message when targeting the OSD */
+   unsigned duration;
+   /* Message priority when targeting the OSD
+    * > When multiple concurrent messages are sent to
+    *   the frontend and the frontend does not have the
+    *   capacity to display them all, messages with the
+    *   *highest* priority value should be shown
+    * > There is no upper limit to a message priority
+    *   value (within the bounds of the unsigned data type)
+    * > In the reference frontend (RetroArch), the same
+    *   priority values are used for frontend-generated
+    *   notifications, which are typically assigned values
+    *   between 0 and 3 depending upon importance */
+   unsigned priority;
+   /* Message logging level (info, warn, error, etc.) */
+   enum retro_log_level level;
+   /* Message destination: OSD, logging interface or both */
+   enum retro_message_target target;
+   /* Message 'type' when targeting the OSD
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION: Specifies that a
+    *   message should be handled in identical fashion to
+    *   a standard frontend-generated notification
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION_ALT: Specifies that
+    *   message is a notification that requires user attention
+    *   or action, but that it should be displayed in a manner
+    *   that differs from standard frontend-generated notifications.
+    *   This would typically correspond to messages that should be
+    *   displayed immediately (independently from any internal
+    *   frontend message queue), and/or which should be visually
+    *   distinguishable from frontend-generated notifications.
+    *   For example, a core may wish to inform the user of
+    *   information related to a disk-change event. It is
+    *   expected that the frontend itself may provide a
+    *   notification in this case; if the core sends a
+    *   message of type RETRO_MESSAGE_TYPE_NOTIFICATION, an
+    *   uncomfortable 'double-notification' may occur. A message
+    *   of RETRO_MESSAGE_TYPE_NOTIFICATION_ALT should therefore
+    *   be presented such that visual conflict with regular
+    *   notifications does not occur
+    * > RETRO_MESSAGE_TYPE_STATUS: Indicates that message
+    *   is not a standard notification. This typically
+    *   corresponds to 'status' indicators, such as a core's
+    *   internal FPS, which are intended to be displayed
+    *   either permanently while a core is running, or in
+    *   a manner that does not suggest user attention or action
+    *   is required. 'Status' type messages should therefore be
+    *   displayed in a different on-screen location and in a manner
+    *   easily distinguishable from both standard frontend-generated
+    *   notifications and messages of type RETRO_MESSAGE_TYPE_NOTIFICATION_ALT
+    * > RETRO_MESSAGE_TYPE_PROGRESS: Indicates that message reports
+    *   the progress of an internal core task. For example, in cases
+    *   where a core itself handles the loading of content from a file,
+    *   this may correspond to the percentage of the file that has been
+    *   read. Alternatively, an audio/video playback core may use a
+    *   message of type RETRO_MESSAGE_TYPE_PROGRESS to display the current
+    *   playback position as a percentage of the runtime. 'Progress' type
+    *   messages should therefore be displayed as a literal progress bar,
+    *   where:
+    *   - 'retro_message_ext.msg' is the progress bar title/label
+    *   - 'retro_message_ext.progress' determines the length of
+    *     the progress bar
+    * NOTE: Message type is a *hint*, and may be ignored
+    * by the frontend. If a frontend lacks support for
+    * displaying messages via alternate means than standard
+    * frontend-generated notifications, it will treat *all*
+    * messages as having the type RETRO_MESSAGE_TYPE_NOTIFICATION */
+   enum retro_message_type type;
+   /* Task progress when targeting the OSD and message is
+    * of type RETRO_MESSAGE_TYPE_PROGRESS
+    * > -1:    Unmetered/indeterminate
+    * > 0-100: Current progress percentage
+    * NOTE: Since message type is a hint, a frontend may ignore
+    * progress values. Where relevant, a core should therefore
+    * include progress percentage within the message string,
+    * such that the message intent remains clear when displayed
+    * as a standard frontend-generated notification */
+   int8_t progress;
+};
+
 /* Describes how the libretro implementation maps a libretro input bind
  * to its internal input system through a human readable string.
  * This string can be used to better let a user configure input. */
@@ -2410,7 +3114,7 @@ struct retro_input_descriptor
 struct retro_system_info
 {
    /* All pointers are owned by libretro implementation, and pointers must
-    * remain valid until retro_deinit() is called. */
+    * remain valid until it is unloaded. */
 
    const char *library_name;      /* Descriptive name of library. Should not
                                    * contain any version numbers, etc. */
@@ -2450,6 +3154,213 @@ struct retro_system_info
     * Necessary for certain libretro implementations that load games
     * from zipped archives. */
    bool        block_extract;
+};
+
+/* Defines overrides which modify frontend handling of
+ * specific content file types.
+ * An array of retro_system_content_info_override is
+ * passed to RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_system_content_info_override
+{
+   /* A list of file extensions for which the override
+    * should apply, delimited by a 'pipe' character
+    * (e.g. "md|sms|gg")
+    * Permitted file extensions are limited to those
+    * included in retro_system_info::valid_extensions
+    * and/or retro_subsystem_rom_info::valid_extensions */
+   const char *extensions;
+
+   /* Overrides the need_fullpath value set in
+    * retro_system_info and/or retro_subsystem_rom_info.
+    * To reiterate:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info::path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info::data and retro_game_info::size are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - retro_game_info::path may be NULL
+    *    - retro_game_info::data and retro_game_info::size are guaranteed
+    *      to be valid
+    *
+    * In addition:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info_ext::full_path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info_ext::archive_path may be NULL
+    *    - retro_game_info_ext::archive_file may be NULL
+    *    - retro_game_info_ext::dir is guaranteed to contain a valid path
+    *      to the directory in which the content file exists
+    *    - retro_game_info_ext::name is guaranteed to contain the
+    *      basename of the content file, without extension
+    *    - retro_game_info_ext::ext is guaranteed to contain the
+    *      extension of the content file in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - If retro_game_info_ext::file_in_archive is false:
+    *       - retro_game_info_ext::full_path is guaranteed to contain
+    *         a valid path to an existent file
+    *       - retro_game_info_ext::archive_path may be NULL
+    *       - retro_game_info_ext::archive_file may be NULL
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the content file exists
+    *       - retro_game_info_ext::name is guaranteed to contain the
+    *         basename of the content file, without extension
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file in lower case format
+    *    - If retro_game_info_ext::file_in_archive is true:
+    *       - retro_game_info_ext::full_path may be NULL
+    *       - retro_game_info_ext::archive_path is guaranteed to
+    *         contain a valid path to an existent compressed file
+    *         inside which the content file is located
+    *       - retro_game_info_ext::archive_file is guaranteed to
+    *         contain a valid path to an existent content file
+    *         inside the compressed file referred to by
+    *         retro_game_info_ext::archive_path
+    *            e.g. for a compressed file '/path/to/foo.zip'
+    *            containing 'bar.sfc'
+    *             > retro_game_info_ext::archive_path will be '/path/to/foo.zip'
+    *             > retro_game_info_ext::archive_file will be 'bar.sfc'
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the compressed file
+    *         (containing the content file) exists
+    *       - retro_game_info_ext::name is guaranteed to contain
+    *         EITHER
+    *         1) the basename of the compressed file (containing
+    *            the content file), without extension
+    *         OR
+    *         2) the basename of the content file inside the
+    *            compressed file, without extension
+    *         In either case, a core should consider 'name' to
+    *         be the canonical name/ID of the the content file
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file inside the compressed file,
+    *         in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size are
+    *      guaranteed to be valid */
+   bool need_fullpath;
+
+   /* If need_fullpath is false, specifies whether the content
+    * data buffer available in retro_load_game() is 'persistent'
+    *
+    * If persistent_data is false and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid only until retro_load_game() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid only until retro_load_game() returns
+    *
+    * If persistent_data is true and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid until retro_deinit() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid until retro_deinit() returns */
+   bool persistent_data;
+};
+
+/* Similar to retro_game_info, but provides extended
+ * information about the source content file and
+ * game memory buffer status.
+ * And array of retro_game_info_ext is returned by
+ * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_game_info_ext
+{
+   /* - If file_in_archive is false, contains a valid
+    *   path to an existent content file (UTF-8 encoded)
+    * - If file_in_archive is true, may be NULL */
+   const char *full_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contains a valid path
+    *   to an existent compressed file inside which the
+    *   content file is located (UTF-8 encoded) */
+   const char *archive_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contain a valid path
+    *   to an existent content file inside the compressed
+    *   file referred to by archive_path (UTF-8 encoded)
+    *      e.g. for a compressed file '/path/to/foo.zip'
+    *      containing 'bar.sfc'
+    *      > archive_path will be '/path/to/foo.zip'
+    *      > archive_file will be 'bar.sfc' */
+   const char *archive_file;
+
+   /* - If file_in_archive is false, contains a valid path
+    *   to the directory in which the content file exists
+    *   (UTF-8 encoded)
+    * - If file_in_archive is true, contains a valid path
+    *   to the directory in which the compressed file
+    *   (containing the content file) exists (UTF-8 encoded) */
+   const char *dir;
+
+   /* Contains the canonical name/ID of the content file
+    * (UTF-8 encoded). Intended for use when identifying
+    * 'complementary' content named after the loaded file -
+    * i.e. companion data of a different format (a CD image
+    * required by a ROM), texture packs, internally handled
+    * save files, etc.
+    * - If file_in_archive is false, contains the basename
+    *   of the content file, without extension
+    * - If file_in_archive is true, then string is
+    *   implementation specific. A frontend may choose to
+    *   set a name value of:
+    *   EITHER
+    *   1) the basename of the compressed file (containing
+    *      the content file), without extension
+    *   OR
+    *   2) the basename of the content file inside the
+    *      compressed file, without extension
+    *   RetroArch sets the 'name' value according to (1).
+    *   A frontend that supports routine loading of
+    *   content from archives containing multiple unrelated
+    *   content files may set the 'name' value according
+    *   to (2). */
+   const char *name;
+
+   /* - If file_in_archive is false, contains the extension
+    *   of the content file in lower case format
+    * - If file_in_archive is true, contains the extension
+    *   of the content file inside the compressed file,
+    *   in lower case format */
+   const char *ext;
+
+   /* String of implementation specific meta-data. */
+   const char *meta;
+
+   /* Memory buffer of loaded game content. Will be NULL:
+    * IF
+    * - retro_system_info::need_fullpath is true and
+    *   retro_system_content_info_override::need_fullpath
+    *   is unset
+    * OR
+    * - retro_system_content_info_override::need_fullpath
+    *   is true */
+   const void *data;
+
+   /* Size of game content memory buffer, in bytes */
+   size_t size;
+
+   /* True if loaded content file is inside a compressed
+    * archive */
+   bool file_in_archive;
+
+   /* - If data is NULL, value is unset/ignored
+    * - If data is non-NULL:
+    *   - If persistent_data is false, data and size are
+    *     valid only until retro_load_game() returns
+    *   - If persistent_data is true, data and size are
+    *     are valid until retro_deinit() returns */
+   bool persistent_data;
 };
 
 struct retro_game_geometry
@@ -2504,8 +3415,20 @@ struct retro_core_option_display
 };
 
 /* Maximum number of values permitted for a core option
- * NOTE: This may be increased on a core-by-core basis
- * if required (doing so has no effect on the frontend) */
+ * > Note: We have to set a maximum value due the limitations
+ *   of the C language - i.e. it is not possible to create an
+ *   array of structs each containing a variable sized array,
+ *   so the retro_core_option_definition values array must
+ *   have a fixed size. The size limit of 128 is a balancing
+ *   act - it needs to be large enough to support all 'sane'
+ *   core options, but setting it too large may impact low memory
+ *   platforms. In practise, if a core option has more than
+ *   128 values then the implementation is likely flawed.
+ *   To quote the above API reference:
+ *      "The number of possible options should be very limited
+ *       i.e. it should be feasible to cycle through options
+ *       without a keyboard."
+ */
 #define RETRO_NUM_CORE_OPTION_VALUES_MAX 128
 
 struct retro_core_option_value
@@ -2549,6 +3472,143 @@ struct retro_core_options_intl
     * - Implementation for current frontend language
     * - May be NULL */
    struct retro_core_option_definition *local;
+};
+
+struct retro_core_option_v2_category
+{
+   /* Variable uniquely identifying the
+    * option category. Valid key characters
+    * are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable category description
+    * > Used as category menu label when
+    *   frontend has core option category
+    *   support */
+   const char *desc;
+
+   /* Human-readable category information
+    * > Used as category menu sublabel when
+    *   frontend has core option category
+    *   support
+    * > Optional (may be NULL or an empty
+    *   string) */
+   const char *info;
+};
+
+struct retro_core_option_v2_definition
+{
+   /* Variable to query in RETRO_ENVIRONMENT_GET_VARIABLE.
+    * Valid key characters are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend does
+    *   not have core option category support
+    *   e.g. "Video > Aspect Ratio" */
+   const char *desc;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend has
+    *   core option category support
+    *   e.g. "Aspect Ratio", where associated
+    *   retro_core_option_v2_category::desc
+    *   is "Video"
+    * > If empty or NULL, the string specified by
+    *   desc will be used as the menu label
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *desc_categorized;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel */
+   const char *info;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel when frontend
+    *   has core option category support
+    *   (e.g. may be required when info text
+    *   references an option by name/desc,
+    *   and the desc/desc_categorized text
+    *   for that option differ)
+    * > If empty or NULL, the string specified by
+    *   info will be used as the menu sublabel
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *info_categorized;
+
+   /* Variable specifying category (e.g. "video",
+    * "audio") that will be assigned to the option
+    * if frontend has core option category support.
+    * > Categorized options will be displayed in a
+    *   subsection/submenu of the frontend core
+    *   option interface
+    * > Specified string must match one of the
+    *   retro_core_option_v2_category::key values
+    *   in the associated retro_core_option_v2_category
+    *   array; If no match is not found, specified
+    *   string will be considered as NULL
+    * > If specified string is empty or NULL, option will
+    *   have no category and will be shown at the top
+    *   level of the frontend core option interface */
+   const char *category_key;
+
+   /* Array of retro_core_option_value structs, terminated by NULL */
+   struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
+};
+
+struct retro_core_options_v2
+{
+   /* Array of retro_core_option_v2_category structs,
+    * terminated by NULL
+    * > If NULL, all entries in definitions array
+    *   will have no category and will be shown at
+    *   the top level of the frontend core option
+    *   interface
+    * > Will be ignored if frontend does not have
+    *   core option category support */
+   struct retro_core_option_v2_category *categories;
+
+   /* Array of retro_core_option_v2_definition structs,
+    * terminated by NULL */
+   struct retro_core_option_v2_definition *definitions;
+};
+
+struct retro_core_options_v2_intl
+{
+   /* Pointer to a retro_core_options_v2 struct
+    * > US English implementation
+    * > Must point to a valid struct */
+   struct retro_core_options_v2 *us;
+
+   /* Pointer to a retro_core_options_v2 struct
+    * - Implementation for current frontend language
+    * - May be NULL */
+   struct retro_core_options_v2 *local;
+};
+
+/* Used by the frontend to monitor changes in core option
+ * visibility. May be called each time any core option
+ * value is set via the frontend.
+ * - On each invocation, the core must update the visibility
+ *   of any dynamically hidden options using the
+ *   RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY environment
+ *   callback.
+ * - On the first invocation, returns 'true' if the visibility
+ *   of any core option has changed since the last call of
+ *   retro_load_game() or retro_load_game_special().
+ * - On each subsequent invocation, returns 'true' if the
+ *   visibility of any core option has changed since the last
+ *   time the function was called. */
+typedef bool (RETRO_CALLCONV *retro_core_options_update_display_callback_t)(void);
+struct retro_core_options_update_display_callback
+{
+   retro_core_options_update_display_callback_t callback;
 };
 
 struct retro_game_info
@@ -2595,6 +3655,84 @@ struct retro_framebuffer
    unsigned memory_flags;           /* Flags telling core how the memory has been mapped.
                                        RETRO_MEMORY_TYPE_* flags.
                                        Set by frontend in GET_CURRENT_SOFTWARE_FRAMEBUFFER. */
+};
+
+/* Used by a libretro core to override the current
+ * fastforwarding mode of the frontend */
+struct retro_fastforwarding_override
+{
+   /* Specifies the runtime speed multiplier that
+    * will be applied when 'fastforward' is true.
+    * For example, a value of 5.0 when running 60 FPS
+    * content will cap the fast-forward rate at 300 FPS.
+    * Note that the target multiplier may not be achieved
+    * if the host hardware has insufficient processing
+    * power.
+    * Setting a value of 0.0 (or greater than 0.0 but
+    * less than 1.0) will result in an uncapped
+    * fast-forward rate (limited only by hardware
+    * capacity).
+    * If the value is negative, it will be ignored
+    * (i.e. the frontend will use a runtime speed
+    * multiplier of its own choosing) */
+   float ratio;
+
+   /* If true, fastforwarding mode will be enabled.
+    * If false, fastforwarding mode will be disabled. */
+   bool fastforward;
+
+   /* If true, and if supported by the frontend, an
+    * on-screen notification will be displayed while
+    * 'fastforward' is true.
+    * If false, and if supported by the frontend, any
+    * on-screen fast-forward notifications will be
+    * suppressed */
+   bool notification;
+
+   /* If true, the core will have sole control over
+    * when fastforwarding mode is enabled/disabled;
+    * the frontend will not be able to change the
+    * state set by 'fastforward' until either
+    * 'inhibit_toggle' is set to false, or the core
+    * is unloaded */
+   bool inhibit_toggle;
+};
+
+/* During normal operation. Rate will be equal to the core's internal FPS. */
+#define RETRO_THROTTLE_NONE              0
+
+/* While paused or stepping single frames. Rate will be 0. */
+#define RETRO_THROTTLE_FRAME_STEPPING    1
+
+/* During fast forwarding.
+ * Rate will be 0 if not specifically limited to a maximum speed. */
+#define RETRO_THROTTLE_FAST_FORWARD      2
+
+/* During slow motion. Rate will be less than the core's internal FPS. */
+#define RETRO_THROTTLE_SLOW_MOTION       3
+
+/* While rewinding recorded save states. Rate can vary depending on the rewind
+ * speed or be 0 if the frontend is not aiming for a specific rate. */
+#define RETRO_THROTTLE_REWINDING         4
+
+/* While vsync is active in the video driver and the target refresh rate is
+ * lower than the core's internal FPS. Rate is the target refresh rate. */
+#define RETRO_THROTTLE_VSYNC             5
+
+/* When the frontend does not throttle in any way. Rate will be 0.
+ * An example could be if no vsync or audio output is active. */
+#define RETRO_THROTTLE_UNBLOCKED         6
+
+struct retro_throttle_state
+{
+   /* The current throttling mode. Should be one of the values above. */
+   unsigned mode;
+
+   /* How many times per second the frontend aims to call retro_run.
+    * Depending on the mode, it can be 0 if there is no known fixed rate.
+    * This won't be accurate if the total processing time of the core and
+    * the frontend is longer than what is available for one frame. */
+   float rate;
 };
 
 /* Callbacks */

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -4,8 +4,31 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../libretro-common/include/libretro.h"
-#include "../libretro-common/include/retro_inline.h"
+#include <libretro.h>
+#include <retro_inline.h>
+
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
+#endif
+
+/*
+ ********************************
+ * VERSION: 2.0
+ ********************************
+ *
+ * - 2.0: Add support for core options v2 interface
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,117 +49,256 @@ extern "C" {
  * - Will be used as a fallback for any missing entries in
  *   frontend language definition */
 
-struct retro_core_option_definition option_defs_us[] = {
+struct retro_core_option_v2_category option_cats_us[] = {
    {
-      "vitaquakeii_framerate",
-      "Framerate (restart)",
-      "Modify framerate. Requires a restart.",
-      {
-         { "auto",            "Auto"},
-         { "50",              "50fps"},
-         { "60",              "60fps"},
-         { "72",              "72fps"},
-         { "75",              "75fps"},
-         { "90",              "90fps"},
-         { "100",              "100fps"},
-         { "119",              "119fps"},
-         { "120",              "120fps"},
-         { "144",              "144fps"},
-         { "155",              "155fps"},
-         { "160",              "160fps"},
-         { "165",              "165fps"},
-         { "180",              "180fps"},
-         { "200",              "200fps"},
-         { "240",              "240fps"},
-         { "244",              "244fps"},
-         { "300",              "300fps"},
-         { "360",              "360fps"},
-         { NULL, NULL },
-      },
-      "auto"
+      "input",
+      "Input",
+      "Configure auto run, Y axis inversion, camera sensitivity, analog deadzone and rumble settings."
    },
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_us[] = {
    {
       "vitaquakeii_resolution",
-      "Internal resolution (restart)",
-      "Configure the resolution. Requires a restart.",
+      "Internal Resolution (Restart)",
+      NULL,
+      "Set the in-game rendering resolution. Higher values improve clarity at the expense of increased performance requirements.",
+      NULL,
+      NULL,
       {
-         { "480x272",   NULL },
-         { "640x368",   NULL },
-         { "720x408",   NULL },
-         { "960x544",   NULL },
+         { "480x272",    NULL },
+         { "640x368",    NULL },
+         { "720x408",    NULL },
+         { "960x544",    NULL },
          { "1280x720",   NULL },
-         { "1920x1080",   NULL },
-         { "2560x1440",   NULL },
-         { "3840x2160",   NULL },
-         { "5120x2880",   NULL },
-         { "7680x4320",   NULL },
-         { "15360x8640",   NULL },
+         { "1920x1080",  NULL },
+         { "2560x1440",  NULL },
+         { "3840x2160",  NULL },
+         { "5120x2880",  NULL },
+         { "7680x4320",  NULL },
+         { "15360x8640", NULL },
          { NULL, NULL },
       },
       "960x544"
    },
    {
-      "vitaquakeii_dithered_filtering",
-      "Dithered filtering",
-      "Enables kernel-based software texture smoothing/filtering. Will take a hit on performance. Only works with the software renderer.",
+      "vitaquakeii_framerate",
+      "Framerate (Restart)",
+      NULL,
+      "Set internal framerate. 'Auto' will attempt to match the refresh rate of the connected display.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Disabled" },
-         { "enabled",   "Enabled" },
+         { "auto", "Auto" },
+         { "50",   "50 fps" },
+         { "60",   "60 fps" },
+         { "72",   "72 fps" },
+         { "75",   "75 fps" },
+         { "90",   "90 fps" },
+         { "100",  "100 fps" },
+         { "119",  "119 fps" },
+         { "120",  "120 fps" },
+         { "144",  "144 fps" },
+         { "155",  "155 fps" },
+         { "160",  "160 fps" },
+         { "165",  "165 fps" },
+         { "180",  "180 fps" },
+         { "200",  "200 fps" },
+         { "240",  "240 fps" },
+         { "244",  "244 fps" },
+         { "300",  "300 fps" },
+         { "360",  "360 fps" },
+         { NULL, NULL },
+      },
+      "auto"
+   },
+   {
+      "vitaquakeii_gamma",
+      "Gamma Level (Restart)",
+      NULL,
+      "Set the overall gamma offset of the rendered image. Higher values make shadows brighter, but can produce a flatter, washed out picture. Lower values make shadows darker, improving contrast but obscuring detail.",
+      NULL,
+      NULL,
+      {
+         { "0.20", NULL },
+         { "0.22", NULL },
+         { "0.24", NULL },
+         { "0.26", NULL },
+         { "0.28", NULL },
+         { "0.30", NULL },
+         { "0.32", NULL },
+         { "0.34", NULL },
+         { "0.36", NULL },
+         { "0.38", NULL },
+         { "0.40", NULL },
+         { "0.42", NULL },
+         { "0.44", NULL },
+         { "0.46", NULL },
+         { "0.48", NULL },
+         { "0.50", NULL },
+         { "0.52", NULL },
+         { "0.54", NULL },
+         { "0.56", NULL },
+         { "0.58", NULL },
+         { "0.60", NULL },
+         { "0.62", NULL },
+         { "0.64", NULL },
+         { "0.66", NULL },
+         { "0.68", NULL },
+         { "0.70", NULL },
+         { "0.72", NULL },
+         { "0.74", NULL },
+         { "0.76", NULL },
+         { "0.78", NULL },
+         { "0.80", NULL },
+         { "0.82", NULL },
+         { "0.84", NULL },
+         { "0.86", NULL },
+         { "0.88", NULL },
+         { "0.90", NULL },
+         { "0.92", NULL },
+         { "0.94", NULL },
+         { "0.96", NULL },
+         { "0.98", NULL },
+         { "1.00", NULL },
+         { NULL, NULL },
+      },
+      "0.50"
+   },
+#ifdef HAVE_OPENGL
+   {
+      "vitaquakeii_renderer",
+      "Renderer (Restart)",
+      NULL,
+      "Choose between fast hardware-accelerated (OpenGL) rendering or the slower software-based renderer.",
+      NULL,
+      NULL,
+      {
+         { "opengl",   "OpenGL" },
+         { "software", "Software" },
+         { NULL, NULL },
+      },
+      "opengl"
+   },
+   {
+      "vitaquakeii_gl_modulate",
+      "[GL] Brightness (Restart)",
+      NULL,
+      "Set the overall brightness of in-game environments. (Only supported by the OpenGL renderer)",
+      NULL,
+      NULL,
+      {
+         { "1.0", NULL },
+         { "1.2", NULL },
+         { "1.4", NULL },
+         { "1.6", NULL },
+         { "1.8", NULL },
+         { "2.0", NULL },
+         { "2.2", NULL },
+         { "2.4", NULL },
+         { "2.6", NULL },
+         { "2.8", NULL },
+         { "3.0", NULL },
+         { "3.2", NULL },
+         { "3.4", NULL },
+         { "3.6", NULL },
+         { "3.8", NULL },
+         { "4.0", NULL },
+         { "4.2", NULL },
+         { "4.4", NULL },
+         { "4.6", NULL },
+         { "4.8", NULL },
+         { "5.0", NULL },
+         { NULL, NULL },
+      },
+      "2.0"
+   },
+   {
+      "vitaquakeii_gl_texture_filtering",
+      "[GL] Texture Filtering",
+      NULL,
+      "Set hardware-based filtering method for in-game textures. 'Nearest' is sharp, 'Linear' is smooth. 'HQ' versions improve mipmap handling, reducing 'shimmer' in floor/ceiling textures. (Only supported by the OpenGL renderer)",
+      NULL,
+      NULL,
+      {
+         { "nearest",    "Nearest" },
+         { "linear",     "Linear" },
+         { "nearest_hq", "Nearest (HQ)" },
+         { "linear_hq",  "Linear (HQ)" },
+         { NULL, NULL },
+      },
+      "nearest_hq"
+   },
+   {
+      "vitaquakeii_gl_shadows",
+      "[GL] Dynamic Shadows",
+      NULL,
+      "Enable the casting of dynamic shadows from in-game objects. (Only supported by the OpenGL renderer)",
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
       "disabled"
    },
    {
-      "vitaquakeii_shadows",
-      "Dynamic Shadows",
-      "Enables dynamic shadows rendering. Only works with the hardware renderer.",
+      "vitaquakeii_gl_gl_xflip",
+      "[GL] Mirror Mode",
+      NULL,
+      "Mirror each level by flipping the X coordinate of the display, providing an alternative experience for veteran players. (Only supported by the OpenGL renderer)",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Disabled" },
-         { "enabled",   "Enabled" },
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+#endif
+   {
+      "vitaquakeii_sw_dithered_filtering",
+      "[SW] Dithered Filtering",
+      NULL,
+      "Reduce pixelation of in-game textures at the expense of increased performance requirements. (Only supported by the Software renderer)",
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
       "disabled"
    },
    {
-      "vitaquakeii_rumble",
-      "Rumble",
-      "Enables joypad rumble.",
+      "vitaquakeii_hand",
+      "Weapon Position",
+      NULL,
+      "Set the on-screen location of the currently held weapon.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Disabled" },
-         { "enabled",   "Enabled" },
+         { "right",  "Right" },
+         { "left",   "Left" },
+         { "center", "Center" },
+         { "hidden", "Hidden" },
          { NULL, NULL },
       },
-      "enabled"
-   },
-   {
-      "vitaquakeii_specular",
-      "Specular Mode",
-      "Makes every level be specular. Only works with the hardware renderer.",
-      {
-         { "disabled",  "Disabled" },
-         { "enabled",   "Enabled" },
-         { NULL, NULL },
-      },
-      "disabled"
+      "right"
    },
    {
       "vitaquakeii_xhair",
       "Show Crosshair",
-      "Enables in game crosshair.",
+      NULL,
+      "Enable an in-game crosshair to facilitate aiming.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Disabled" },
-         { "enabled",   "Enabled" },
-         { NULL, NULL },
-      },
-      "enabled"
-   },
-   {
-      "vitaquakeii_invert_y_axis",
-      "Invert Y Axis",
-      "Invert the gamepad right analog stick's Y axis.",
-      {
-         { "disabled",  "Disabled" },
-         { "enabled",   "Enabled" },
+         { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
       "enabled"
@@ -144,214 +306,127 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "vitaquakeii_fps",
       "Show FPS",
-      "Shows framerate on top right screen.",
+      NULL,
+      "Enable an internal framerate counter (indicator is shown at the top right corner of the screen).",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Disabled" },
-         { "enabled",   "Enabled" },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-#ifdef HAVE_OPENGL
-   {
-      "vitaquakeii_renderer",
-      "Renderer (restart)",
-      "Choose whether to use software renderer or OpenGL.",
-      {
-         { "opengl",    "OpenGL" },
-	 { "software",  "Software" },
-         { NULL, NULL },
-      },
-      "opengl"
-   },
-#endif
-   {
-      "vitaquakeii_hand",
-      "Weapon Position",
-      "Change positioning for the held weapon.",
-      {
-         { "right",  "Right" },
-         { "left",   "Left" },
-		 { "center", "Center" },
-		 { "hidden", "Hidden" },
-         { NULL, NULL },
-      },
-      "right"
-   },
-   { NULL, NULL, NULL, {{0}}, NULL },
-};
-
-/* RETRO_LANGUAGE_JAPANESE */
-
-/* RETRO_LANGUAGE_FRENCH */
-
-/* RETRO_LANGUAGE_SPANISH */
-
-/* RETRO_LANGUAGE_GERMAN */
-
-/* RETRO_LANGUAGE_ITALIAN */
-struct retro_core_option_definition option_defs_it[] = {
-   {
-      "vitaquakeii_framerate",
-      "Framerate (riavvio)",
-      "Modifica il framerate. Richiede un riavvio.",
-      {
-         { "auto",            "Auto"},
-         { "50",              "50fps"},
-         { "60",              "60fps"},
-         { "72",              "72fps"},
-         { "75",              "75fps"},
-         { "90",              "90fps"},
-         { "100",              "100fps"},
-         { "119",              "119fps"},
-         { "120",              "120fps"},
-         { "144",              "144fps"},
-         { "155",              "155fps"},
-         { "160",              "160fps"},
-         { "165",              "165fps"},
-         { "180",              "180fps"},
-         { "200",              "200fps"},
-         { "240",              "240fps"},
-         { "244",              "244fps"},
-         { NULL, NULL },
-      },
-      "auto"
-   },
-   {
-      "vitaquakeii_resolution",
-      "Risoluzione interna (riavvio)",
-      "Configura la risoluzione. Richiede un riavvio.",
-      {
-         { "480x272",   NULL },
-         { "640x368",   NULL },
-         { "720x408",   NULL },
-         { "960x544",   NULL },
-		 { "1280x720",   NULL },
-		 { "1920x1080",   NULL },
-		 { "2560x1440",   NULL },
-		 { "3840x2160",   NULL },
-         { NULL, NULL },
-      },
-      "960x544"
-   },
-   {
-      "vitaquakeii_dithered_filtering",
-      "Filtro Dithering",
-      "Abilita filtraggio software kernel-based per le texture. Riduce le performance. Funziona solo con renderer software.",
-      {
-         { "disabled",  "Disattivato" },
-         { "enabled",   "Attivato" },
+         { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
       "disabled"
    },
    {
-      "vitaquakeii_shadows",
-      "Ombre Dinamiche",
-      "Abilita il rendering delle ombre dinamiche. Funziona solo con renderer hardware.",
+      "vitaquakeii_cl_run",
+      "Auto Run",
+      NULL,
+      "When enabled, the player character will run by default instead of walking.",
+      NULL,
+      "input",
       {
-         { "disabled",  "Disattivato" },
-         { "enabled",   "Attivato" },
+         { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
       "disabled"
-   },
-   {
-      "vitaquakeii_rumble",
-      "Vibrazione",
-      "Abilita la vibrazione del joypad.",
-      {
-         { "disabled",  "Disattivata" },
-         { "enabled",   "Attivata" },
-         { NULL, NULL },
-      },
-      "enabled"
-   },
-   {
-      "vitaquakeii_specular",
-      "Modalità Speculare",
-      "Rende tutti i livelli di gioco speculari. Funziona solo con renderer hardware.",
-      {
-         { "disabled",  "Disattivata" },
-         { "enabled",   "Attivata" },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "vitaquakeii_xhair",
-      "Mostra Mirino",
-      "Abilita il mirino in gioco.",
-      {
-         { "disabled",  "Disattivato" },
-         { "enabled",   "Attivato" },
-         { NULL, NULL },
-      },
-      "enabled"
    },
    {
       "vitaquakeii_invert_y_axis",
-      "Inverti Asse Y",
-      "Inverte l'asse Y dell'analogico destro.",
+      "Invert Y Axis",
+      NULL,
+      "Invert the Y axis of the gamepad's right analog stick. When disabled, pressing 'up' will make the player character look down (i.e. flight sim camera controls).",
+      NULL,
+      "input",
       {
-         { "disabled",  "Disattivato" },
-         { "enabled",   "Attivato" },
+         { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
       "enabled"
    },
    {
-      "vitaquakeii_fps",
-      "Mostra FPS",
-      "Mostra il framerate nell'angolo in alto a destra dello schermo.",
+      "vitaquakeii_mouse_sensitivity",
+      "Camera Sensitivity",
+      NULL,
+      "Set the base speed of camera movements when using the gamepad's right analog stick.",
+      NULL,
+      "input",
       {
-         { "disabled",  "Disattivato" },
-         { "enabled",   "Attivato" },
+         { "0.4", NULL },
+         { "0.6", NULL },
+         { "0.8", NULL },
+         { "1.0", NULL },
+         { "1.2", NULL },
+         { "1.4", NULL },
+         { "1.6", NULL },
+         { "1.8", NULL },
+         { "2.0", NULL },
+         { "2.2", NULL },
+         { "2.4", NULL },
+         { "2.6", NULL },
+         { "2.8", NULL },
+         { "3.0", NULL },
+         { "3.2", NULL },
+         { "3.4", NULL },
+         { "3.6", NULL },
+         { "3.8", NULL },
+         { "4.0", NULL },
+         { "4.2", NULL },
+         { "4.4", NULL },
+         { "4.6", NULL },
+         { "4.8", NULL },
+         { "5.0", NULL },
+         { NULL, NULL },
+      },
+      "3.0"
+   },
+   {
+      "vitaquakeii_analog_deadzone",
+      "Analog Deadzone",
+      NULL,
+      "Set the deadzone of the gamepad's analog sticks. May be used to eliminate controller drift.",
+      NULL,
+      "input",
+      {
+         { "0",  "0%" },
+         { "3",  "3%" },
+         { "5",  "5%" },
+         { "7",  "7%" },
+         { "10", "10%" },
+         { "13", "13%" },
+         { "15", "15%" },
+         { "17", "17%" },
+         { "20", "20%" },
+         { "23", "23%" },
+         { "25", "25%" },
+         { "27", "27%" },
+         { "30", "30%" },
+         { NULL, NULL },
+      },
+      "15"
+   },
+   {
+      "vitaquakeii_rumble",
+      "Rumble Effects",
+      NULL,
+      "Enable gamepad force feedback when receiving damage.",
+      NULL,
+      "input",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
       "disabled"
    },
-   {
-      "vitaquakeii_hand",
-      "Posizione dell'Arma",
-      "Cambia la posizione dell'arma in uso.",
-      {
-         { "right",  "Destra" },
-         { "left",   "Sinistra" },
-		 { "center", "Centro" },
-		 { "hidden", "Nascosta" },
-         { NULL, NULL },
-      },
-      "right"
-   },
-   { NULL, NULL, NULL, {{0}}, NULL },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
 };
 
-/* RETRO_LANGUAGE_DUTCH */
-
-/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
-
-/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
-
-/* RETRO_LANGUAGE_RUSSIAN */
-
-/* RETRO_LANGUAGE_KOREAN */
-
-/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
-
-/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
-
-/* RETRO_LANGUAGE_ESPERANTO */
-
-/* RETRO_LANGUAGE_POLISH */
-
-/* RETRO_LANGUAGE_VIETNAMESE */
-
-/* RETRO_LANGUAGE_ARABIC */
-
-/* RETRO_LANGUAGE_GREEK */
-
-/* RETRO_LANGUAGE_TURKISH */
+struct retro_core_options_v2 options_us = {
+   option_cats_us,
+   option_defs_us
+};
 
 /*
  ********************************
@@ -359,27 +434,34 @@ struct retro_core_option_definition option_defs_it[] = {
  ********************************
 */
 
-struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
-   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
-   NULL,           /* RETRO_LANGUAGE_JAPANESE */
-   NULL,           /* RETRO_LANGUAGE_FRENCH */
-   NULL,           /* RETRO_LANGUAGE_SPANISH */
-   NULL,           /* RETRO_LANGUAGE_GERMAN */
-   option_defs_it, /* RETRO_LANGUAGE_ITALIAN */
-   NULL,           /* RETRO_LANGUAGE_DUTCH */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
-   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
-   NULL,           /* RETRO_LANGUAGE_KOREAN */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
-   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
-   NULL,           /* RETRO_LANGUAGE_POLISH */
-   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
-   NULL,           /* RETRO_LANGUAGE_ARABIC */
-   NULL,           /* RETRO_LANGUAGE_GREEK */
-   NULL,           /* RETRO_LANGUAGE_TURKISH */
+#ifndef HAVE_NO_LANGEXTRA
+struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
+   &options_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,        /* RETRO_LANGUAGE_JAPANESE */
+   NULL,        /* RETRO_LANGUAGE_FRENCH */
+   NULL,        /* RETRO_LANGUAGE_SPANISH */
+   NULL,        /* RETRO_LANGUAGE_GERMAN */
+   NULL,        /* RETRO_LANGUAGE_ITALIAN */
+   NULL,        /* RETRO_LANGUAGE_DUTCH */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,        /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,        /* RETRO_LANGUAGE_KOREAN */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,        /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,        /* RETRO_LANGUAGE_POLISH */
+   NULL,        /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,        /* RETRO_LANGUAGE_ARABIC */
+   NULL,        /* RETRO_LANGUAGE_GREEK */
+   NULL,        /* RETRO_LANGUAGE_TURKISH */
+   NULL,        /* RETRO_LANGUAGE_SLOVAK */
+   NULL,        /* RETRO_LANGUAGE_PERSIAN */
+   NULL,        /* RETRO_LANGUAGE_HEBREW */
+   NULL,        /* RETRO_LANGUAGE_ASTURIAN */
+   NULL,        /* RETRO_LANGUAGE_FINNISH */
 };
+#endif
 
 /*
  ********************************
@@ -388,41 +470,68 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
 */
 
 /* Handles configuration/setting of core options.
- * Should only be called inside retro_set_environment().
+ * Should be called as early as possible - ideally inside
+ * retro_set_environment(), and no later than retro_load_game()
  * > We place the function body in the header to avoid the
  *   necessity of adding more .c files (i.e. want this to
  *   be as painless as possible for core devs)
  */
 
-static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
+      bool *categories_supported)
 {
-   unsigned version = 0;
+   unsigned version  = 0;
+#ifndef HAVE_NO_LANGEXTRA
+   unsigned language = 0;
+#endif
 
-   if (!environ_cb)
+   if (!environ_cb || !categories_supported)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
-   {
-      struct retro_core_options_intl core_options_intl;
-      unsigned language = 0;
+   *categories_supported = false;
 
-      core_options_intl.us    = option_defs_us;
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
+      version = 0;
+
+   if (version >= 2)
+   {
+#ifndef HAVE_NO_LANGEXTRA
+      struct retro_core_options_v2_intl core_options_intl;
+
+      core_options_intl.us    = &options_us;
       core_options_intl.local = NULL;
 
       if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
           (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
-         core_options_intl.local = option_defs_intl[language];
+         core_options_intl.local = options_intl[language];
 
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,
+            &core_options_intl);
+#else
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+            &options_us);
+#endif
    }
    else
    {
-      size_t i;
+      size_t i, j;
+      size_t option_index              = 0;
       size_t num_options               = 0;
+      struct retro_core_option_definition
+            *option_v1_defs_us         = NULL;
+#ifndef HAVE_NO_LANGEXTRA
+      size_t num_options_intl          = 0;
+      struct retro_core_option_v2_definition
+            *option_defs_intl          = NULL;
+      struct retro_core_option_definition
+            *option_v1_defs_intl       = NULL;
+      struct retro_core_options_intl
+            core_options_v1_intl;
+#endif
       struct retro_variable *variables = NULL;
       char **values_buf                = NULL;
 
-      /* Determine number of options */
+      /* Determine total number of options */
       while (true)
       {
          if (option_defs_us[num_options].key)
@@ -431,86 +540,187 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             break;
       }
 
-      /* Allocate arrays */
-      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
-      values_buf = (char **)calloc(num_options, sizeof(char *));
-
-      if (!variables || !values_buf)
-         goto error;
-
-      /* Copy parameters from option_defs_us array */
-      for (i = 0; i < num_options; i++)
+      if (version >= 1)
       {
-         const char *key                        = option_defs_us[i].key;
-         const char *desc                       = option_defs_us[i].desc;
-         const char *default_value              = option_defs_us[i].default_value;
-         struct retro_core_option_value *values = option_defs_us[i].values;
-         size_t buf_len                         = 3;
-         size_t default_index                   = 0;
+         /* Allocate US array */
+         option_v1_defs_us = (struct retro_core_option_definition *)
+               calloc(num_options + 1, sizeof(struct retro_core_option_definition));
 
-         values_buf[i] = NULL;
-
-         if (desc)
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
          {
-            size_t num_values = 0;
+            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];
+            struct retro_core_option_value *option_values         = option_def_us->values;
+            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];
+            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;
 
-            /* Determine number of values */
+            option_v1_def_us->key           = option_def_us->key;
+            option_v1_def_us->desc          = option_def_us->desc;
+            option_v1_def_us->info          = option_def_us->info;
+            option_v1_def_us->default_value = option_def_us->default_value;
+
+            /* Values must be copied individually... */
+            while (option_values->value)
+            {
+               option_v1_values->value = option_values->value;
+               option_v1_values->label = option_values->label;
+
+               option_values++;
+               option_v1_values++;
+            }
+         }
+
+#ifndef HAVE_NO_LANGEXTRA
+         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&
+             options_intl[language])
+            option_defs_intl = options_intl[language]->definitions;
+
+         if (option_defs_intl)
+         {
+            /* Determine number of intl options */
             while (true)
             {
-               if (values[num_values].value)
-               {
-                  /* Check if this is the default value */
-                  if (default_value)
-                     if (strcmp(values[num_values].value, default_value) == 0)
-                        default_index = num_values;
-
-                  buf_len += strlen(values[num_values].value);
-                  num_values++;
-               }
+               if (option_defs_intl[num_options_intl].key)
+                  num_options_intl++;
                else
                   break;
             }
 
-            /* Build values string */
-            if (num_values > 1)
+            /* Allocate intl array */
+            option_v1_defs_intl = (struct retro_core_option_definition *)
+                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));
+
+            /* Copy parameters from option_defs_intl array */
+            for (i = 0; i < num_options_intl; i++)
             {
-               size_t j;
+               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];
+               struct retro_core_option_value *option_values           = option_def_intl->values;
+               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];
+               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;
 
-               buf_len += num_values - 1;
-               buf_len += strlen(desc);
+               option_v1_def_intl->key           = option_def_intl->key;
+               option_v1_def_intl->desc          = option_def_intl->desc;
+               option_v1_def_intl->info          = option_def_intl->info;
+               option_v1_def_intl->default_value = option_def_intl->default_value;
 
-               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
-               if (!values_buf[i])
-                  goto error;
-
-               strcpy(values_buf[i], desc);
-               strcat(values_buf[i], "; ");
-
-               /* Default value goes first */
-               strcat(values_buf[i], values[default_index].value);
-
-               /* Add remaining values */
-               for (j = 0; j < num_values; j++)
+               /* Values must be copied individually... */
+               while (option_values->value)
                {
-                  if (j != default_index)
-                  {
-                     strcat(values_buf[i], "|");
-                     strcat(values_buf[i], values[j].value);
-                  }
+                  option_v1_values->value = option_values->value;
+                  option_v1_values->label = option_values->label;
+
+                  option_values++;
+                  option_v1_values++;
                }
             }
          }
 
-         variables[i].key   = key;
-         variables[i].value = values_buf[i];
+         core_options_v1_intl.us    = option_v1_defs_us;
+         core_options_v1_intl.local = option_v1_defs_intl;
+
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);
+#else
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);
+#endif
       }
-      
-      /* Set variables */
-      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+      else
+      {
+         /* Allocate arrays */
+         variables  = (struct retro_variable *)calloc(num_options + 1,
+               sizeof(struct retro_variable));
+         values_buf = (char **)calloc(num_options, sizeof(char *));
+
+         if (!variables || !values_buf)
+            goto error;
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            const char *key                        = option_defs_us[i].key;
+            const char *desc                       = option_defs_us[i].desc;
+            const char *default_value              = option_defs_us[i].default_value;
+            struct retro_core_option_value *values = option_defs_us[i].values;
+            size_t buf_len                         = 3;
+            size_t default_index                   = 0;
+
+            values_buf[i] = NULL;
+
+            if (desc)
+            {
+               size_t num_values = 0;
+
+               /* Determine number of values */
+               while (true)
+               {
+                  if (values[num_values].value)
+                  {
+                     /* Check if this is the default value */
+                     if (default_value)
+                        if (strcmp(values[num_values].value, default_value) == 0)
+                           default_index = num_values;
+
+                     buf_len += strlen(values[num_values].value);
+                     num_values++;
+                  }
+                  else
+                     break;
+               }
+
+               /* Build values string */
+               if (num_values > 0)
+               {
+                  buf_len += num_values - 1;
+                  buf_len += strlen(desc);
+
+                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+                  if (!values_buf[i])
+                     goto error;
+
+                  strcpy(values_buf[i], desc);
+                  strcat(values_buf[i], "; ");
+
+                  /* Default value goes first */
+                  strcat(values_buf[i], values[default_index].value);
+
+                  /* Add remaining values */
+                  for (j = 0; j < num_values; j++)
+                  {
+                     if (j != default_index)
+                     {
+                        strcat(values_buf[i], "|");
+                        strcat(values_buf[i], values[j].value);
+                     }
+                  }
+               }
+            }
+
+            variables[option_index].key   = key;
+            variables[option_index].value = values_buf[i];
+            option_index++;
+         }
+
+         /* Set variables */
+         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+      }
 
 error:
-
       /* Clean up */
+
+      if (option_v1_defs_us)
+      {
+         free(option_v1_defs_us);
+         option_v1_defs_us = NULL;
+      }
+
+#ifndef HAVE_NO_LANGEXTRA
+      if (option_v1_defs_intl)
+      {
+         free(option_v1_defs_intl);
+         option_v1_defs_intl = NULL;
+      }
+#endif
+
       if (values_buf)
       {
          for (i = 0; i < num_options; i++)

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -1,0 +1,91 @@
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include <libretro.h>
+
+/*
+ ********************************
+ * VERSION: 2.0
+ ********************************
+ *
+ * - 2.0: Add support for core options v2 interface
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+/* RETRO_LANGUAGE_SLOVAK */
+
+/* RETRO_LANGUAGE_PERSIAN */
+
+/* RETRO_LANGUAGE_HEBREW */
+
+/* RETRO_LANGUAGE_ASTURIAN */
+
+/* RETRO_LANGUAGE_FINNISH */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libretro/swimpl.c
+++ b/libretro/swimpl.c
@@ -73,7 +73,7 @@ rserr_t		SWimp_SetMode( int *pwidth, int *pheight, int mode, qboolean fullscreen
 	vid.rowbytes = scr_width;
 	vid.buffer = malloc(scr_width*scr_height);
 	
-	tex_buffer = malloc(scr_width*scr_height*2);
+	tex_buffer = malloc(scr_width*scr_height*sizeof(uint16_t));
 	
 	SWimp_SetPalette((const unsigned char*)start_palette);
 	

--- a/qcommon/common.c
+++ b/qcommon/common.c
@@ -1460,10 +1460,16 @@ void Qcommon_Init (int argc, char **argv)
 
 	Cbuf_AddText ("exec default.cfg\n");
 
-	Sys_DefaultConfig();
-	
+	//Sys_DefaultConfig();
+
 	Cbuf_AddText ("exec config.cfg\n");
-	
+
+	// For the libretro core, a number of default
+	// settings are essential for correct operation
+	// > Must ensure that these *override* anything
+	//   in default.cfg or config.cfg
+	Sys_DefaultConfig();
+
 	Cbuf_AddEarlyCommands (true);
 	Cbuf_Execute ();
 

--- a/qcommon/files.c
+++ b/qcommon/files.c
@@ -766,6 +766,7 @@ char *FS_NextPath (char *prevpath)
 }
 
 extern char g_rom_dir[1024];
+extern char g_save_dir[1024];
 
 /*
 ================
@@ -790,6 +791,10 @@ void FS_InitFilesystem (void)
 	// start up with baseq2 by default
 	//
 	FS_AddGameDirectory (va("%s/"BASEDIRNAME, fs_basedir->string) );
+
+	// Add save directory to search paths
+	if (g_save_dir[0] != '\0')
+		FS_AddGameDirectory (g_save_dir);
 
 	// any set gamedirs will be freed up to here
 	fs_base_searchpaths = fs_searchpaths;

--- a/ref_gl/gl_draw.c
+++ b/ref_gl/gl_draw.c
@@ -265,12 +265,21 @@ Draw_FadeScreen
 
 ================
 */
-void Draw_FadeScreen (void)
+void Draw_FadeScreen (int transparent)
 {
+	/* TODO/FIXME: DrawQuad_NoTex() is currently
+	 * non-functional, so we have to ignore 'transparent'
+	 * and just clear the screen... */
+#if 0
 	qglEnable (GL_BLEND);
 	DrawQuad_NoTex(0, 0, vid.width, vid.height, 0, 0, 0, 0.8f);
 	qglColor4f (1,1,1,1);
 	qglDisable (GL_BLEND);
+#endif
+
+	qglClearColor ((float)0x0f / 255.0f, (float)0x0c / 255.0f, (float)0x07 / 255.0f, 1.0);
+	qglClear (GL_COLOR_BUFFER_BIT);
+	qglClearColor (1, 0, 0.5, 0.5);
 }
 
 

--- a/ref_gl/gl_image.c
+++ b/ref_gl/gl_image.c
@@ -138,7 +138,7 @@ qboolean GL_Upload32 (uint32_t *data, int width, int height,  qboolean mipmap)
 	else
 		GL_ResampleTexture (data, width, height, scaled, scaled_width, scaled_height);
 
-	//GL_LightScaleTexture (scaled, scaled_width, scaled_height, !mipmap );
+	GL_LightScaleTexture (scaled, scaled_width, scaled_height, !mipmap );
 
 	qglTexImage2D( GL_TEXTURE_2D, 0, comp, scaled_width, scaled_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, scaled );
 

--- a/ref_gl/gl_local.h
+++ b/ref_gl/gl_local.h
@@ -289,7 +289,7 @@ void	Draw_StretchPic (int x, int y, int w, int h, char *name);
 void	Draw_Char (int x, int y, int c, float factor);
 void	Draw_TileClear (int x, int y, int w, int h, char *name);
 void	Draw_Fill (int x, int y, int w, int h, int c);
-void	Draw_FadeScreen (void);
+void	Draw_FadeScreen (int transparent);
 void	Draw_StretchRaw (int x, int y, int w, int h, int cols, int rows, byte *data);
 
 void	R_SwapBuffers( int );

--- a/ref_gl/gl_rmain.c
+++ b/ref_gl/gl_rmain.c
@@ -923,6 +923,8 @@ static void R_RenderFrame (refdef_t *fd)
 	R_SetGL2D ();
 }
 
+extern float libretro_gamma;
+extern float libretro_gl_modulate;
 
 void R_Register( void )
 {
@@ -948,7 +950,9 @@ void R_Register( void )
 	gl_particle_att_b = ri.Cvar_Get( "gl_particle_att_b", "0.0", CVAR_ARCHIVE );
 	gl_particle_att_c = ri.Cvar_Get( "gl_particle_att_c", "0.01", CVAR_ARCHIVE );
 
-	gl_modulate = ri.Cvar_Get ("gl_modulate", "1", CVAR_ARCHIVE );
+	gl_modulate = ri.Cvar_Get ("gl_modulate", "4.0", CVAR_ARCHIVE );
+	ri.Cvar_SetValue( "gl_modulate", libretro_gl_modulate );
+
 	gl_log = ri.Cvar_Get( "gl_log", "0", 0 );
 	gl_bitdepth = ri.Cvar_Get( "gl_bitdepth", "0", 0 );
 	gl_mode = ri.Cvar_Get( "gl_mode", "3", CVAR_ARCHIVE );
@@ -985,7 +989,10 @@ void R_Register( void )
 	gl_playermip = ri.Cvar_Get ("gl_playermip", "0", 0);
 	gl_monolightmap = ri.Cvar_Get( "gl_monolightmap", "0", 0 );
 	gl_driver = ri.Cvar_Get( "gl_driver", "opengl32", CVAR_ARCHIVE );
-	gl_texturemode = ri.Cvar_Get( "gl_texturemode", "GL_LINEAR", CVAR_ARCHIVE );
+
+	gl_texturemode = ri.Cvar_Get( "gl_texturemode", "GL_NEAREST_MIPMAP_LINEAR", CVAR_ARCHIVE );
+	ri.Cvar_Set( "gl_texturemode", "GL_NEAREST_MIPMAP_LINEAR" );
+
 	gl_texturealphamode = ri.Cvar_Get( "gl_texturealphamode", "default", CVAR_ARCHIVE );
 	gl_texturesolidmode = ri.Cvar_Get( "gl_texturesolidmode", "default", CVAR_ARCHIVE );
 	gl_lockpvs = ri.Cvar_Get( "gl_lockpvs", "0", 0 );
@@ -1006,7 +1013,10 @@ void R_Register( void )
 	gl_3dlabs_broken = ri.Cvar_Get( "gl_3dlabs_broken", "1", CVAR_ARCHIVE );
 
 	vid_fullscreen = ri.Cvar_Get( "vid_fullscreen", "0", CVAR_ARCHIVE );
+
 	vid_refgl_gamma = ri.Cvar_Get( "vid_gamma", "1.0", CVAR_ARCHIVE );
+	ri.Cvar_SetValue( "vid_gamma", libretro_gamma );
+
 	vid_ref = ri.Cvar_Get( "vid_ref", "soft", CVAR_ARCHIVE );
 	
 	gl_xflip = ri.Cvar_Get( "gl_xflip", "0", CVAR_ARCHIVE);
@@ -1402,7 +1412,7 @@ void	Draw_Pic (int x, int y, char *name, float factor);
 void	Draw_Char (int x, int y, int c, float factor);
 void	Draw_TileClear (int x, int y, int w, int h, char *name);
 void	Draw_Fill (int x, int y, int w, int h, int c);
-void	Draw_FadeScreen (void);
+void	Draw_FadeScreen (int transparent);
 
 /*
 @@@@@@@@@@@@@@@@@@@@@

--- a/ref_soft/r_draw.c
+++ b/ref_soft/r_draw.c
@@ -419,21 +419,26 @@ SWR_Draw_FadeScreen
 
 ================
 */
-void SWR_Draw_FadeScreen(void)
+void SWR_Draw_FadeScreen(int transparent)
 {
-	int			x, y;
-	byte		*pbuf;
-	int	t;
-
-	for (y = 0; y < vid.height; y++)
+	if (transparent)
 	{
-		pbuf = (byte *)(vid.buffer + vid.rowbytes*y);
-		t = (y & 1) << 1;
+		int   x, y;
+		byte  *pbuf;
+		int   t;
 
-		for (x=0 ; x<vid.width ; x++)
+		for (y = 0; y < vid.height; y++)
 		{
-			if ((x & 3) != t)
-				pbuf[x] = 0;
+			pbuf = (byte *)(vid.buffer + vid.rowbytes*y);
+			t = (y & 1) << 1;
+
+			for (x=0 ; x<vid.width ; x++)
+			{
+				if ((x & 3) != t)
+					pbuf[x] = 0;
+			}
 		}
 	}
+	else
+		SWR_Draw_Fill (0, 0, vid.width, vid.height, 0);
 }

--- a/ref_soft/r_local.h
+++ b/ref_soft/r_local.h
@@ -86,7 +86,7 @@ typedef struct
 	pixel_t                 *buffer;                // invisible buffer
 	pixel_t                 *colormap;              // 256 * VID_GRADES size
 	pixel_t                 *alphamap;              // 256 * 256 translucency map
-	int                             rowbytes;               // may be > width if displayed in a window
+	int                      rowbytes;              // may be > width if displayed in a window
 									// can be negative for stupid dibs
 	int						width;          
 	int						height;
@@ -768,7 +768,7 @@ void    SWR_Draw_StretchRaw (int x, int y, int w, int h, int cols, int rows, byt
 void    SWR_Draw_Char (int x, int y, int c, float scale);
 void    SWR_Draw_TileClear (int x, int y, int w, int h, char *name);
 void    SWR_Draw_Fill (int x, int y, int w, int h, int c);
-void    SWR_Draw_FadeScreen (void);
+void    SWR_Draw_FadeScreen (int transparent);
 
 void	R_CinematicSetPalette( const unsigned char *palette );
 

--- a/ref_soft/r_main.c
+++ b/ref_soft/r_main.c
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "r_local.h"
 
-extern viddef_t	vid;
+viddef_t	vid;
 
 unsigned	d_refsoft_8to24table[256];
 
@@ -277,6 +277,8 @@ extern cvar_t *gl_xflip;
 #else
 cvar_t *gl_xflip;
 #endif
+extern float libretro_gamma;
+
 void SWR_Register (void)
 {
 	sw_aliasstats = ri.Cvar_Get ("sw_polymodelstats", "0", 0);
@@ -307,7 +309,9 @@ void SWR_Register (void)
 	r_novis = ri.Cvar_Get( "r_novis", "0", 0 );
 
 	vid_fullscreen = ri.Cvar_Get( "vid_fullscreen", "0", CVAR_ARCHIVE );
+
 	vid_gamma = ri.Cvar_Get( "vid_gamma", "1.0", CVAR_ARCHIVE );
+	ri.Cvar_SetValue( "vid_gamma", libretro_gamma );
 
 	ri.Cmd_AddCommand ("modellist", SWR_Mod_Modellist_f);
 	ri.Cmd_AddCommand( "screenshot", R_ScreenShot_f );
@@ -1356,12 +1360,14 @@ static void Draw_GetPalette (void)
 	byte	*pal, *out;
 	int		i;
 	int		r, g, b;
+	int		width, height;
 
 	// get the palette and colormap
-	LoadPCX ("pics/colormap.pcx", &vid.colormap, &pal, NULL, NULL);
-	if (!vid.colormap)
+	LoadPCX ("pics/colormap.pcx", &vid.colormap, &pal, &width, &height);
+	if (!vid.colormap || ((width * height) < (256 * VID_GRADES) + (256 * 256)))
 		ri.Sys_Error (ERR_FATAL, "Couldn't load pics/colormap.pcx");
-	vid.alphamap = vid.colormap + 64*256;
+
+	vid.alphamap = vid.colormap + (256 * VID_GRADES);
 
 	out = (byte *)d_refsoft_8to24table;
 	for (i=0 ; i<256 ; i++, out+=4)

--- a/rogue/player/hud.c
+++ b/rogue/player/hud.c
@@ -382,6 +382,8 @@ InventoryMessage(edict_t *ent)
 
 /* ======================================================================= */
 
+extern void IN_StartRumble (void);
+
 void
 G_SetStats(edict_t *ent)
 {
@@ -396,6 +398,13 @@ G_SetStats(edict_t *ent)
 
 	/* health */
 	ent->client->ps.stats[STAT_HEALTH_ICON] = level.pic_health;
+
+	/* Health is decreasing, trigger a rumble on PSTV */
+	if (ent->client->ps.stats[STAT_HEALTH] > ent->health)
+	{
+		IN_StartRumble();
+	}
+
 	ent->client->ps.stats[STAT_HEALTH] = ent->health;
 
 	/* ammo */

--- a/server/sv_ccmds.c
+++ b/server/sv_ccmds.c
@@ -20,6 +20,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "server.h"
 
+extern char g_save_dir[1024];
+
 /*
 ===============================================================================
 
@@ -157,15 +159,19 @@ void SV_WipeSavegame (char *savename)
 {
 	char	name[MAX_OSPATH];
 	char	*s;
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	Com_DPrintf("SV_WipeSaveGame(%s)\n", savename);
 
-	Com_sprintf (name, sizeof(name), "%s/save/%s/server.ssv", FS_Gamedir (), savename);
+	Com_sprintf (name, sizeof(name), "%s/save/%s/server.ssv", savedir, savename);
 	remove (name);
-	Com_sprintf (name, sizeof(name), "%s/save/%s/game.ssv", FS_Gamedir (), savename);
+	Com_sprintf (name, sizeof(name), "%s/save/%s/game.ssv", savedir, savename);
 	remove (name);
 
-	Com_sprintf (name, sizeof(name), "%s/save/%s/*.sav", FS_Gamedir (), savename);
+	Com_sprintf (name, sizeof(name), "%s/save/%s/*.sav", savedir, savename);
 	s = Sys_FindFirst( name, 0, 0 );
 	while (s)
 	{
@@ -173,7 +179,7 @@ void SV_WipeSavegame (char *savename)
 		s = Sys_FindNext( 0, 0 );
 	}
 	Sys_FindClose ();
-	Com_sprintf (name, sizeof(name), "%s/save/%s/*.sv2", FS_Gamedir (), savename);
+	Com_sprintf (name, sizeof(name), "%s/save/%s/*.sv2", savedir, savename);
 	s = Sys_FindFirst(name, 0, 0 );
 	while (s)
 	{
@@ -230,30 +236,34 @@ void SV_CopySaveGame (char *src, char *dst)
 	char	name[MAX_OSPATH], name2[MAX_OSPATH];
 	int		l, len;
 	char	*found;
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	Com_DPrintf("SV_CopySaveGame(%s, %s)\n", src, dst);
 
 	SV_WipeSavegame (dst);
 
 	// copy the savegame over
-	Com_sprintf (name, sizeof(name), "%s/save/%s/server.ssv", FS_Gamedir(), src);
-	Com_sprintf (name2, sizeof(name2), "%s/save/%s/server.ssv", FS_Gamedir(), dst);
+	Com_sprintf (name, sizeof(name), "%s/save/%s/server.ssv", savedir, src);
+	Com_sprintf (name2, sizeof(name2), "%s/save/%s/server.ssv", savedir, dst);
 	FS_CreatePath (name2);
 	CopyFile (name, name2);
 
-	Com_sprintf (name, sizeof(name), "%s/save/%s/game.ssv", FS_Gamedir(), src);
-	Com_sprintf (name2, sizeof(name2), "%s/save/%s/game.ssv", FS_Gamedir(), dst);
+	Com_sprintf (name, sizeof(name), "%s/save/%s/game.ssv", savedir, src);
+	Com_sprintf (name2, sizeof(name2), "%s/save/%s/game.ssv", savedir, dst);
 	CopyFile (name, name2);
 
-	Com_sprintf (name, sizeof(name), "%s/save/%s/", FS_Gamedir(), src);
+	Com_sprintf (name, sizeof(name), "%s/save/%s/", savedir, src);
 	len = strlen(name);
-	Com_sprintf (name, sizeof(name), "%s/save/%s/*.sav", FS_Gamedir(), src);
+	Com_sprintf (name, sizeof(name), "%s/save/%s/*.sav", savedir, src);
 	found = Sys_FindFirst(name, 0, 0 );
 	while (found)
 	{
 		strcpy (name+len, found+len);
 
-		Com_sprintf (name2, sizeof(name2), "%s/save/%s/%s", FS_Gamedir(), dst, found+len);
+		Com_sprintf (name2, sizeof(name2), "%s/save/%s/%s", savedir, dst, found+len);
 		CopyFile (name, name2);
 
 		// change sav to sv2
@@ -279,10 +289,14 @@ void SV_WriteLevelFile (void)
 {
 	char	name[MAX_OSPATH];
 	FILE	*f;
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	Com_DPrintf("SV_WriteLevelFile()\n");
 
-	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sv2", FS_Gamedir(), sv.name);
+	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sv2", savedir, sv.name);
 	f = fopen(name, "wb");
 	if (!f)
 	{
@@ -293,7 +307,7 @@ void SV_WriteLevelFile (void)
 	CM_WritePortalState (f);
 	fclose (f);
 
-	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sav", FS_Gamedir(), sv.name);
+	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sav", savedir, sv.name);
 	ge->WriteLevel (name);
 }
 
@@ -307,10 +321,14 @@ void SV_ReadLevelFile (void)
 {
 	char	name[MAX_OSPATH];
 	FILE	*f;
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	Com_DPrintf("SV_ReadLevelFile()\n");
 
-	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sv2", FS_Gamedir(), sv.name);
+	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sv2", savedir, sv.name);
 	f = fopen(name, "rb");
 	if (!f)
 	{
@@ -321,7 +339,7 @@ void SV_ReadLevelFile (void)
 	CM_ReadPortalState (f);
 	fclose (f);
 
-	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sav", FS_Gamedir(), sv.name);
+	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sav", savedir, sv.name);
 	ge->ReadLevel (name);
 }
 
@@ -339,10 +357,14 @@ void SV_WriteServerFile (qboolean autosave)
 	char	comment[32];
 	time_t	aclock;
 	struct tm	*newtime;
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	Com_DPrintf("SV_WriteServerFile(%s)\n", autosave ? "true" : "false");
 
-	Com_sprintf (name, sizeof(name), "%s/save/current/server.ssv", FS_Gamedir());
+	Com_sprintf (name, sizeof(name), "%s/save/current/server.ssv", savedir);
 	f = fopen (name, "wb");
 	if (!f)
 	{
@@ -394,7 +416,7 @@ void SV_WriteServerFile (qboolean autosave)
 	fclose (f);
 
 	// write game state
-	Com_sprintf (name, sizeof(name), "%s/save/current/game.ssv", FS_Gamedir());
+	Com_sprintf (name, sizeof(name), "%s/save/current/game.ssv", savedir);
 	ge->WriteGame (name, autosave);
 }
 
@@ -410,10 +432,14 @@ void SV_ReadServerFile (void)
 	char	name[MAX_OSPATH], string[128];
 	char	comment[32];
 	char	mapcmd[MAX_TOKEN_CHARS];
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	Com_DPrintf("SV_ReadServerFile()\n");
 
-	Com_sprintf (name, sizeof(name), "%s/save/current/server.ssv", FS_Gamedir());
+	Com_sprintf (name, sizeof(name), "%s/save/current/server.ssv", savedir);
 	f = fopen (name, "rb");
 	if (!f)
 	{
@@ -445,7 +471,7 @@ void SV_ReadServerFile (void)
 	strcpy (svs.mapcmd, mapcmd);
 
 	// read game state
-	Com_sprintf (name, sizeof(name), "%s/save/current/game.ssv", FS_Gamedir());
+	Com_sprintf (name, sizeof(name), "%s/save/current/game.ssv", savedir);
 	ge->ReadGame (name);
 }
 
@@ -491,6 +517,10 @@ void SV_GameMap_f (void)
 	int			i;
 	client_t	*cl;
 	qboolean	*savedInuse;
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	if (Cmd_Argc() != 2)
 	{
@@ -500,7 +530,7 @@ void SV_GameMap_f (void)
 
 	Com_DPrintf("SV_GameMap(%s)\n", Cmd_Argv(1));
 
-	FS_CreatePath (va("%s/save/current/", FS_Gamedir()));
+	FS_CreatePath (va("%s/save/current/", savedir));
 
 	// check for clearing the current savegame
 	map = Cmd_Argv(1);
@@ -596,6 +626,10 @@ void SV_Loadgame_f (void)
 	char	name[MAX_OSPATH];
 	FILE	*f;
 	char	*dir;
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	if (Cmd_Argc() != 2)
 	{
@@ -612,7 +646,7 @@ void SV_Loadgame_f (void)
 	}
 
 	// make sure the server.ssv file exists
-	Com_sprintf (name, sizeof(name), "%s/save/%s/server.ssv", FS_Gamedir(), Cmd_Argv(1));
+	Com_sprintf (name, sizeof(name), "%s/save/%s/server.ssv", savedir, Cmd_Argv(1));
 	f = fopen (name, "rb");
 	if (!f)
 	{
@@ -886,6 +920,10 @@ void SV_ServerRecord_f (void)
 	sizebuf_t	buf;
 	int		len;
 	int		i;
+	char  *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	if (Cmd_Argc() != 2)
 	{
@@ -908,7 +946,7 @@ void SV_ServerRecord_f (void)
 	//
 	// open the demo file
 	//
-	Com_sprintf (name, sizeof(name), "%s/demos/%s.dm2", FS_Gamedir(), Cmd_Argv(1));
+	Com_sprintf (name, sizeof(name), "%s/demos/%s.dm2", savedir, Cmd_Argv(1));
 
 	Com_Printf ("recording to %s.\n", name);
 	FS_CreatePath (name);

--- a/server/sv_init.c
+++ b/server/sv_init.c
@@ -108,6 +108,7 @@ void SV_CreateBaseline (void)
 	}
 }
 
+extern char g_save_dir[1024];
 
 /*
 =================
@@ -116,9 +117,13 @@ SV_CheckForSavegame
 */
 void SV_CheckForSavegame (void)
 {
-	char		name[MAX_OSPATH];
-	FILE		*f;
-	int			i;
+	char     name[MAX_OSPATH];
+	FILE     *f;
+	int      i;
+	char     *savedir = g_save_dir;
+
+	if (g_save_dir[0] == '\0')
+		savedir = FS_Gamedir ();
 
 	if (sv_noreload->value)
 		return;
@@ -126,7 +131,7 @@ void SV_CheckForSavegame (void)
 	if (Cvar_VariableValue ("deathmatch"))
 		return;
 
-	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sav", FS_Gamedir(), sv.name);
+	Com_sprintf (name, sizeof(name), "%s/save/current/%s.sav", savedir, sv.name);
 	f = fopen (name, "rb");
 	if (!f)
 		return;		// no savegame
@@ -431,7 +436,11 @@ void SV_Map (qboolean attractloop, char *levelstring, qboolean loadgame)
 
 	// skip the end-of-unit flag if necessary
 	if (level[0] == '*')
-		strcpy (level, level+1);
+	{
+		char tmp[MAX_QPATH];
+		strcpy (tmp, level+1);
+		strcpy (level, tmp);
+	}
 
 	l = strlen(level);
 	if (l > 4 && !strcmp (level+l-4, ".cin") )

--- a/xatrix/player/hud.c
+++ b/xatrix/player/hud.c
@@ -367,6 +367,8 @@ InventoryMessage(edict_t *ent)
 
 /* ======================================================================= */
 
+extern void IN_StartRumble (void);
+
 void
 G_SetStats(edict_t *ent)
 {
@@ -381,6 +383,13 @@ G_SetStats(edict_t *ent)
 
 	/* health */
 	ent->client->ps.stats[STAT_HEALTH_ICON] = level.pic_health;
+
+	/* Health is decreasing, trigger a rumble on PSTV */
+	if (ent->client->ps.stats[STAT_HEALTH] > ent->health)
+	{
+		IN_StartRumble();
+	}
+
 	ent->client->ps.stats[STAT_HEALTH] = ent->health;
 
 	/* ammo */

--- a/zaero/player/hud.c
+++ b/zaero/player/hud.c
@@ -358,6 +358,9 @@ void Cmd_Help_f (edict_t *ent)
 G_SetStats
 ===============
 */
+
+extern void IN_StartRumble (void);
+
 void G_SetStats (edict_t *ent)
 {
 	gitem_t		*item;
@@ -370,6 +373,13 @@ void G_SetStats (edict_t *ent)
 	// health
 	//
 	ent->client->ps.stats[STAT_HEALTH_ICON] = level.pic_health;
+
+	// Health is decreasing, trigger a rumble on PSTV
+	if (ent->client->ps.stats[STAT_HEALTH] > ent->health)
+	{
+		IN_StartRumble();
+	}
+
 	ent->client->ps.stats[STAT_HEALTH] = ent->health;
 
 	//


### PR DESCRIPTION
At present, the vitaquake2 core is in very poor condition. This PR represents the minimum amount of work required to bring the core to a (mostly) usable state. It makes the following changes:

- Fixes segfaults (which prevented the core from even running on many platforms) due to:
    - Illegal use of `strcpy()` when handling path strings
    - Illegal use of `realloc()` in the memory 'hunk' handling code
    -  Severe memory corruption when using the Software renderer: an extern struct was created in one file then used in another with a *different* type definition, such that half the members were pointing to invalid addresses...
- Moves all core-generated files (saves + `config.cfg`) to the frontend save directory (these were previously dumped in the game directory)
- Removes irrelevant entries from the in-game menu (the multiplayer, options, etc. menus had no purpose in the libretro core)
- Fixes screen blanking behind the in-game menu when using the OpenGL renderer
- Updates the core options to v2 format
- Clarifies existing core option labels/sublabels
- Adds a core options category for input-related settings
- Adds new core option: `Gamma Level`
    -  Allows gamma correction for both Software and OpenGL renderers
- Adds new OpenGL core option: `[GL] Brightness`
    - Sets overall 'environment' brightness when using the OpenGL renderer
    - Default OpenGL brightness has been set to a usable level (previously almost nothing could be seen...)
- Adds new OpenGL core option: `[GL] Texture Filtering`
    - Allows selection of linear or nearest-neighbour filtering for textures, with 'HQ' variants that improve mipmap handling (reducing the movement-induced 'shimmer' effect on floor/ceiling textures)
- Adds new core option: `Analog Deadzone`
    - Used to eliminate controller drift
- Adds new core option: `Auto Run`
    -  Enables running by default
- Adds new core option:  `Camera Sensitivity`
    - Sets the speed of camera movement using the right analog stick
- Fixes gamepad mapping (and adds proper input descriptors) by replacing the botched copy/paste code from tyrquake. The default controls are now laid out as follows:
    - JOYPAD_LEFT: Open Inventory
    - JOYPAD_UP: Menu Up
    - JOYPAD_DOWN: Menu Down
    - JOYPAD_RIGHT: Use Inventory Item
    - JOYPAD_B: Menu Cancel
    - JOYPAD_A: Menu Select
    - JOYPAD_Y: Next Weapon
    - JOYPAD_L: Run
    - JOYPAD_R: Crouch / Descend
    - JOYPAD_L2: Jump / Climb
    - JOYPAD_R2: Attack
    - JOYPAD_R3: Drop Inventory Item
    - JOYPAD_SELECT: Show / Hide Help Computer
    - JOYPAD_START: Show Menu
- Fixes rumble functionality (previously, the `Rumble` core option did nothing...)
- Fixes mirrored controls when using the Software renderer with the OpenGL-only `[GL] Mirror Mode` core option enabled
- Improves the uniformity of left/right and up/down camera movement speed (previously, up/down motion was too fast)
- Ensures a valid framerate is selected when the `Framerate` core option is set to `Auto` (previously this would fail if display refresh rate was set to e.g. 59.950 Hz)
- Ensures core is properly shut down when 'closing content' via the frontend
- Fixes a number of memory leaks

There remains a great deal of work to do on this core, but this is at least a reasonable start.

