### PR TITLE
Fix compatibility with expansion packs + add expansion pack cores to gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,24 @@
     JNI_PATH: .
     CORENAME: vitaquake2
 
+.core-defs-rogue:
+  variables:
+    JNI_PATH: .
+    basegame: rogue
+    CORENAME: vitaquake2-rogue
+
+.core-defs-xatrix:
+  variables:
+    JNI_PATH: .
+    basegame: xatrix
+    CORENAME: vitaquake2-xatrix
+
+.core-defs-zaero:
+  variables:
+    JNI_PATH: .
+    basegame: zaero
+    CORENAME: vitaquake2-zaero
+
 # Inclusion templates, required for the build to work
 include:
   ################################## DESKTOPS ################################
@@ -85,7 +103,11 @@ stages:
 ##############################################################################
 #################################### STAGES ##################################
 ##############################################################################
-#
+
+################
+## vitaquake2 ##
+################
+
 ################################### DESKTOPS #################################
 # Windows 64-bit
 libretro-build-windows-x64:
@@ -197,5 +219,359 @@ libretro-build-emscripten:
   extends:
     - .libretro-emscripten-static-retroarch-master
     - .core-defs
+  variables:
+    EM_MEMORY: 402653184
+
+######################
+## vitaquake2-rogue ##
+######################
+
+################################### DESKTOPS #################################
+# Windows 64-bit
+libretro-build-windows-x64-rogue:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs-rogue
+
+# Windows 32-bit
+libretro-build-windows-i686-rogue:
+  extends:
+    - .libretro-windows-i686-mingw-make-default
+    - .core-defs-rogue
+
+# Linux 64-bit
+libretro-build-linux-x64-rogue:
+  extends:
+    - .libretro-linux-x64-make-default
+    - .core-defs-rogue
+
+# Linux 32-bit
+libretro-build-linux-i686-rogue:
+  extends:
+    - .libretro-linux-i686-make-default
+    - .core-defs-rogue
+
+# MacOS 64-bit
+libretro-build-osx-x64-rogue:
+  extends:
+    - .libretro-osx-x64-make-default
+    - .core-defs-rogue
+
+# MacOS ARM 64-bit
+libretro-build-osx-arm64-rogue:
+  extends:
+    - .libretro-osx-arm64-make-default
+    - .core-defs-rogue
+
+################################### CELLULAR #################################
+# Android ARMv7a
+android-armeabi-v7a-rogue:
+  extends:
+    - .libretro-android-jni-armeabi-v7a
+    - .core-defs-rogue
+    
+# Android ARMv8a
+android-arm64-v8a-rogue:
+  extends:
+    - .core-defs-rogue
+    - .libretro-android-jni-arm64-v8a
+
+# Android 64-bit x86
+android-x86_64-rogue:
+  extends:
+    - .core-defs-rogue
+    - .libretro-android-jni-x86_64
+
+# Android 32-bit x86
+android-x86-rogue:
+  extends:
+    - .libretro-android-jni-x86
+    - .core-defs-rogue
+
+# iOS
+libretro-build-ios-arm64-rogue:
+  extends:
+    - .libretro-ios-arm64-make-default
+    - .core-defs-rogue
+
+# iOS (armv7) [iOS 9 and up]
+libretro-build-ios9-rogue:
+  extends:
+    - .libretro-ios9-make-default
+    - .core-defs-rogue
+    
+# tvOS
+libretro-build-tvos-arm64-rogue:
+  extends:
+    - .libretro-tvos-arm64-make-default
+    - .core-defs-rogue
+
+################################### CONSOLES #################################
+# Nintendo 3DS
+libretro-build-ctr-rogue:
+  extends:
+    - .libretro-ctr-static-retroarch-master
+    - .core-defs-rogue
+    
+# Nintendo WiiU
+libretro-build-wiiu-rogue:
+  extends:
+    - .libretro-wiiu-static-retroarch-master
+    - .core-defs-rogue
+    
+# Nintendo Switch
+libretro-build-libnx-aarch64-rogue:
+  extends:
+    - .libretro-libnx-static-retroarch-master
+    - .core-defs-rogue
+
+# PlayStation Vita
+libretro-build-vita-rogue:
+  extends:
+    - .libretro-vita-static-retroarch-master
+    - .core-defs-rogue
+
+#################################### MISC ##################################
+# Emscripten
+libretro-build-emscripten-rogue:
+  extends:
+    - .libretro-emscripten-static-retroarch-master
+    - .core-defs-rogue
+  variables:
+    EM_MEMORY: 402653184
+
+#######################
+## vitaquake2-xatrix ##
+#######################
+
+################################### DESKTOPS #################################
+# Windows 64-bit
+libretro-build-windows-x64-xatrix:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs-xatrix
+
+# Windows 32-bit
+libretro-build-windows-i686-xatrix:
+  extends:
+    - .libretro-windows-i686-mingw-make-default
+    - .core-defs-xatrix
+
+# Linux 64-bit
+libretro-build-linux-x64-xatrix:
+  extends:
+    - .libretro-linux-x64-make-default
+    - .core-defs-xatrix
+
+# Linux 32-bit
+libretro-build-linux-i686-xatrix:
+  extends:
+    - .libretro-linux-i686-make-default
+    - .core-defs-xatrix
+
+# MacOS 64-bit
+libretro-build-osx-x64-xatrix:
+  extends:
+    - .libretro-osx-x64-make-default
+    - .core-defs-xatrix
+
+# MacOS ARM 64-bit
+libretro-build-osx-arm64-xatrix:
+  extends:
+    - .libretro-osx-arm64-make-default
+    - .core-defs-xatrix
+
+################################### CELLULAR #################################
+# Android ARMv7a
+android-armeabi-v7a-xatrix:
+  extends:
+    - .libretro-android-jni-armeabi-v7a
+    - .core-defs-xatrix
+    
+# Android ARMv8a
+android-arm64-v8a-xatrix:
+  extends:
+    - .core-defs-xatrix
+    - .libretro-android-jni-arm64-v8a
+
+# Android 64-bit x86
+android-x86_64-xatrix:
+  extends:
+    - .core-defs-xatrix
+    - .libretro-android-jni-x86_64
+
+# Android 32-bit x86
+android-x86-xatrix:
+  extends:
+    - .libretro-android-jni-x86
+    - .core-defs-xatrix
+
+# iOS
+libretro-build-ios-arm64-xatrix:
+  extends:
+    - .libretro-ios-arm64-make-default
+    - .core-defs-xatrix
+
+# iOS (armv7) [iOS 9 and up]
+libretro-build-ios9-xatrix:
+  extends:
+    - .libretro-ios9-make-default
+    - .core-defs-xatrix
+    
+# tvOS
+libretro-build-tvos-arm64-xatrix:
+  extends:
+    - .libretro-tvos-arm64-make-default
+    - .core-defs-xatrix
+
+################################### CONSOLES #################################
+# Nintendo 3DS
+libretro-build-ctr-xatrix:
+  extends:
+    - .libretro-ctr-static-retroarch-master
+    - .core-defs-xatrix
+    
+# Nintendo WiiU
+libretro-build-wiiu-xatrix:
+  extends:
+    - .libretro-wiiu-static-retroarch-master
+    - .core-defs-xatrix
+    
+# Nintendo Switch
+libretro-build-libnx-aarch64-xatrix:
+  extends:
+    - .libretro-libnx-static-retroarch-master
+    - .core-defs-xatrix
+
+# PlayStation Vita
+libretro-build-vita-xatrix:
+  extends:
+    - .libretro-vita-static-retroarch-master
+    - .core-defs-xatrix
+
+#################################### MISC ##################################
+# Emscripten
+libretro-build-emscripten-xatrix:
+  extends:
+    - .libretro-emscripten-static-retroarch-master
+    - .core-defs-xatrix
+  variables:
+    EM_MEMORY: 402653184
+
+######################
+## vitaquake2-zaero ##
+######################
+
+################################### DESKTOPS #################################
+# Windows 64-bit
+libretro-build-windows-x64-zaero:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs-zaero
+
+# Windows 32-bit
+libretro-build-windows-i686-zaero:
+  extends:
+    - .libretro-windows-i686-mingw-make-default
+    - .core-defs-zaero
+
+# Linux 64-bit
+libretro-build-linux-x64-zaero:
+  extends:
+    - .libretro-linux-x64-make-default
+    - .core-defs-zaero
+
+# Linux 32-bit
+libretro-build-linux-i686-zaero:
+  extends:
+    - .libretro-linux-i686-make-default
+    - .core-defs-zaero
+
+# MacOS 64-bit
+libretro-build-osx-x64-zaero:
+  extends:
+    - .libretro-osx-x64-make-default
+    - .core-defs-zaero
+
+# MacOS ARM 64-bit
+libretro-build-osx-arm64-zaero:
+  extends:
+    - .libretro-osx-arm64-make-default
+    - .core-defs-zaero
+
+################################### CELLULAR #################################
+# Android ARMv7a
+android-armeabi-v7a-zaero:
+  extends:
+    - .libretro-android-jni-armeabi-v7a
+    - .core-defs-zaero
+    
+# Android ARMv8a
+android-arm64-v8a-zaero:
+  extends:
+    - .core-defs-zaero
+    - .libretro-android-jni-arm64-v8a
+
+# Android 64-bit x86
+android-x86_64-zaero:
+  extends:
+    - .core-defs-zaero
+    - .libretro-android-jni-x86_64
+
+# Android 32-bit x86
+android-x86-zaero:
+  extends:
+    - .libretro-android-jni-x86
+    - .core-defs-zaero
+
+# iOS
+libretro-build-ios-arm64-zaero:
+  extends:
+    - .libretro-ios-arm64-make-default
+    - .core-defs-zaero
+
+# iOS (armv7) [iOS 9 and up]
+libretro-build-ios9-zaero:
+  extends:
+    - .libretro-ios9-make-default
+    - .core-defs-zaero
+    
+# tvOS
+libretro-build-tvos-arm64-zaero:
+  extends:
+    - .libretro-tvos-arm64-make-default
+    - .core-defs-zaero
+
+################################### CONSOLES #################################
+# Nintendo 3DS
+libretro-build-ctr-zaero:
+  extends:
+    - .libretro-ctr-static-retroarch-master
+    - .core-defs-zaero
+    
+# Nintendo WiiU
+libretro-build-wiiu-zaero:
+  extends:
+    - .libretro-wiiu-static-retroarch-master
+    - .core-defs-zaero
+    
+# Nintendo Switch
+libretro-build-libnx-aarch64-zaero:
+  extends:
+    - .libretro-libnx-static-retroarch-master
+    - .core-defs-zaero
+
+# PlayStation Vita
+libretro-build-vita-zaero:
+  extends:
+    - .libretro-vita-static-retroarch-master
+    - .core-defs-zaero
+
+#################################### MISC ##################################
+# Emscripten
+libretro-build-emscripten-zaero:
+  extends:
+    - .libretro-emscripten-static-retroarch-master
+    - .core-defs-zaero
   variables:
     EM_MEMORY: 402653184

--- a/game/header/shared.h
+++ b/game/header/shared.h
@@ -18,11 +18,15 @@
 #include <stdlib.h>
 #include <time.h>
 
-typedef unsigned char byte;
-#define qboolean byte
-#define false 0
-#define true 1
-//typedef enum {false, true}  qboolean;
+typedef unsigned char 		byte;
+#if (defined(__cplusplus) || !defined(PSP2))
+#ifndef PSP2
+#include <stdbool.h>
+#endif
+#define qboolean bool
+#else
+typedef enum {false, true}	qboolean;
+#endif
 
 #ifndef NULL
  #define NULL ((void *)0)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -7,6 +7,14 @@ include $(LOCAL_PATH)/../Makefile.common
 
 COREFLAGS := -DINLINE=inline -DHAVE_STDINT_H -DHAVE_INTTYPES_H -D__LIBRETRO__  -DLIBRETRO -DGAME_HARD_LINKED=1 -DREF_HARD_LINKED -fPIC
 
+ifeq ($(basegame),xatrix)
+COREFLAGS += -DXATRIX
+else ifeq ($(basegame),rogue)
+COREFLAGS += -DROGUE
+else ifeq ($(basegame),zaero)
+COREFLAGS += -DZAERO
+endif
+
 include $(CLEAR_VARS)
 LOCAL_MODULE    := retro
 LOCAL_SRC_FILES := $(SOURCES_CXX) $(SOURCES_C)

--- a/rogue/header/local.h
+++ b/rogue/header/local.h
@@ -31,7 +31,11 @@
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #define max(a, b) ((a) > (b) ? (a) : (b))
+#ifdef _WIN32
+#include <math.h>
+#else
 #define _isnan(a) (isnan(a))
+#endif
 
 /* ================================================================== */
 

--- a/rogue/header/shared.h
+++ b/rogue/header/shared.h
@@ -18,8 +18,15 @@
 #include <stdlib.h>
 #include <time.h>
 
-typedef unsigned char byte;
-typedef enum {false, true}  qboolean;
+typedef unsigned char 		byte;
+#if (defined(__cplusplus) || !defined(PSP2))
+#ifndef PSP2
+#include <stdbool.h>
+#endif
+#define qboolean bool
+#else
+typedef enum {false, true}	qboolean;
+#endif
 
 #ifndef NULL
  #define NULL ((void *)0)

--- a/rogue/savegame/savegame.c
+++ b/rogue/savegame/savegame.c
@@ -53,17 +53,20 @@
  */
 #define SAVEGAMEVER "YQ2-4"
 
+#define YQ2OSTYPE "libretro"
+#define YQ2ARCH "unknown"
+
 /*
  * This macros are used to prohibit loading of savegames
  * created on other systems or architectures. This will
  * crash q2 in spectacular ways
  */
-#ifndef OSTYPE
-#error OSTYPE should be defined by the build system
+#ifndef YQ2OSTYPE
+#error YQ2OSTYPE should be defined by the build system
 #endif
 
-#ifndef ARCH
-#error ARCH should be defined by the build system
+#ifndef YQ2ARCH
+#error YQ2ARCH should be defined by the build system
 #endif
 
 /*
@@ -788,8 +791,8 @@ WriteGame(const char *filename, qboolean autosave)
 
 	strncpy(str_ver, SAVEGAMEVER, sizeof(str_ver) - 1);
 	strncpy(str_game, GAMEVERSION, sizeof(str_game) - 1);
-	strncpy(str_os, OSTYPE, sizeof(str_os) - 1);
-    strncpy(str_arch, ARCH, sizeof(str_arch) - 1);
+	strncpy(str_os, YQ2OSTYPE, sizeof(str_os) - 1);
+    strncpy(str_arch, YQ2ARCH, sizeof(str_arch) - 1);
 
 	fwrite(str_ver, sizeof(str_ver), 1, f);
 	fwrite(str_game, sizeof(str_game), 1, f);
@@ -848,12 +851,12 @@ ReadGame(const char *filename)
 			fclose(f);
 			gi.error("Savegame from an other game.so.\n");
 		}
-		else if (strcmp(str_os, OSTYPE))
+		else if (strcmp(str_os, YQ2OSTYPE))
 		{
 			fclose(f);
 			gi.error("Savegame from an other os.\n");
 		}
-		else if (strcmp(str_arch, ARCH))
+		else if (strcmp(str_arch, YQ2ARCH))
 		{
 			fclose(f);
 			gi.error("Savegame from an other architecure.\n");
@@ -868,12 +871,12 @@ ReadGame(const char *filename)
 			fclose(f);
 			gi.error("Savegame from an other game.so.\n");
 		}
-		else if (strcmp(str_os, OSTYPE))
+		else if (strcmp(str_os, YQ2OSTYPE))
 		{
 			fclose(f);
 			gi.error("Savegame from an other os.\n");
 		}
-		else if (strcmp(str_arch, ARCH))
+		else if (strcmp(str_arch, YQ2ARCH))
 		{
 			fclose(f);
 			gi.error("Savegame from an other architecure.\n");

--- a/rogue/shared/shared.c
+++ b/rogue/shared/shared.c
@@ -7,6 +7,9 @@
  */
 
 #include <ctype.h>
+#ifdef EMSCRIPTEN
+#include <strings.h>
+#endif
 
 #include "../header/shared.h"
 

--- a/xatrix/header/shared.h
+++ b/xatrix/header/shared.h
@@ -18,8 +18,15 @@
 #include <stdlib.h>
 #include <time.h>
 
-typedef unsigned char byte;
-typedef enum {false, true} qboolean;
+typedef unsigned char 		byte;
+#if (defined(__cplusplus) || !defined(PSP2))
+#ifndef PSP2
+#include <stdbool.h>
+#endif
+#define qboolean bool
+#else
+typedef enum {false, true}	qboolean;
+#endif
 
 #ifndef NULL
  #define NULL ((void *)0)

--- a/xatrix/savegame/savegame.c
+++ b/xatrix/savegame/savegame.c
@@ -53,18 +53,20 @@
 */
 #define SAVEGAMEVER "YQ2-3"
 
+#define YQ2OSTYPE "libretro"
+#define YQ2ARCH "unknown"
 
 /*
  * This macros are used to prohibit loading of savegames
  * created on other systems or architectures. This will
  * crash q2 in spectacular ways
  */
-#ifndef OSTYPE
-#error OSTYPE should be defined by the build system
+#ifndef YQ2OSTYPE
+#error YQ2OSTYPE should be defined by the build system
 #endif
 
-#ifndef ARCH
-#error ARCH should be defined by the build system
+#ifndef YQ2ARCH
+#error YQ2ARCH should be defined by the build system
 #endif
 
 /*
@@ -773,8 +775,8 @@ WriteGame(const char *filename, qboolean autosave)
 
 	strncpy(str_ver, SAVEGAMEVER, sizeof(str_ver) - 1);
 	strncpy(str_game, GAMEVERSION, sizeof(str_game) - 1);
-	strncpy(str_os, OSTYPE, sizeof(str_os) - 1);
-    strncpy(str_arch, ARCH, sizeof(str_arch) - 1);
+	strncpy(str_os, YQ2OSTYPE, sizeof(str_os) - 1);
+    strncpy(str_arch, YQ2ARCH, sizeof(str_arch) - 1);
 
 	fwrite(str_ver, sizeof(str_ver), 1, f);
 	fwrite(str_game, sizeof(str_game), 1, f);
@@ -833,12 +835,12 @@ ReadGame(const char *filename)
 			fclose(f);
 			gi.error("Savegame from an other game.so.\n");
 		}
-		else if (strcmp(str_os, OSTYPE))
+		else if (strcmp(str_os, YQ2OSTYPE))
 		{
 			fclose(f);
 			gi.error("Savegame from an other os.\n");
 		}
-		else if (strcmp(str_arch, ARCH))
+		else if (strcmp(str_arch, YQ2ARCH))
 		{
 			fclose(f);
 			gi.error("Savegame from an other architecure.\n");
@@ -853,12 +855,12 @@ ReadGame(const char *filename)
 			fclose(f);
 			gi.error("Savegame from an other game.so.\n");
 		}
-		else if (strcmp(str_os, OSTYPE))
+		else if (strcmp(str_os, YQ2OSTYPE))
 		{
 			fclose(f);
 			gi.error("Savegame from an other os.\n");
 		}
-		else if (strcmp(str_arch, ARCH))
+		else if (strcmp(str_arch, YQ2ARCH))
 		{
 			fclose(f);
 			gi.error("Savegame from an other architecure.\n");

--- a/xatrix/shared/shared.c
+++ b/xatrix/shared/shared.c
@@ -7,6 +7,9 @@
  */
 
 #include <ctype.h>
+#ifdef EMSCRIPTEN
+#include <strings.h>
+#endif
 
 #include "../header/shared.h"
 

--- a/zaero/header/shared.h
+++ b/zaero/header/shared.h
@@ -18,8 +18,15 @@
 #include <stdlib.h>
 #include <time.h>
 
-typedef unsigned char byte;
-typedef enum {false, true}  qboolean;
+typedef unsigned char 		byte;
+#if (defined(__cplusplus) || !defined(PSP2))
+#ifndef PSP2
+#include <stdbool.h>
+#endif
+#define qboolean bool
+#else
+typedef enum {false, true}	qboolean;
+#endif
 
 #ifndef NULL
  #define NULL ((void *)0)

--- a/zaero/savegame/savegame.c
+++ b/zaero/savegame/savegame.c
@@ -56,17 +56,20 @@
  */
 #define SAVEGAMEVER "YQ2-3"
 
+#define YQ2OSTYPE "libretro"
+#define YQ2ARCH "unknown"
+
 /*
  * This macros are used to prohibit loading of savegames
  * created on other systems or architectures. This will
  * crash q2 in spectacular ways
  */
-#ifndef OSTYPE
-#error OSTYPE should be defined by the build system
+#ifndef YQ2OSTYPE
+#error YQ2OSTYPE should be defined by the build system
 #endif
 
-#ifndef ARCH
-#error ARCH should be defined by the build system
+#ifndef YQ2ARCH
+#error YQ2ARCH should be defined by the build system
 #endif
 
 /*
@@ -763,8 +766,8 @@ WriteGame(const char *filename, qboolean autosave)
 
 	strncpy(str_ver, SAVEGAMEVER, sizeof(str_ver));
 	strncpy(str_game, GAMEVERSION, sizeof(str_game));
-	strncpy(str_os, OSTYPE, sizeof(str_os) - 1);
-    strncpy(str_arch, ARCH, sizeof(str_arch));
+	strncpy(str_os, YQ2OSTYPE, sizeof(str_os) - 1);
+    strncpy(str_arch, YQ2ARCH, sizeof(str_arch));
 
 	fwrite(str_ver, sizeof(str_ver), 1, f);
 	fwrite(str_game, sizeof(str_game), 1, f);
@@ -823,12 +826,12 @@ ReadGame(const char *filename)
 			fclose(f);
 			gi.error("Savegame from an other game.so.\n");
 		}
-		else if (strcmp(str_os, OSTYPE))
+		else if (strcmp(str_os, YQ2OSTYPE))
 		{
 			fclose(f);
 			gi.error("Savegame from an other os.\n");
 		}
-		else if (strcmp(str_arch, ARCH))
+		else if (strcmp(str_arch, YQ2ARCH))
 		{
 			fclose(f);
 			gi.error("Savegame from an other architecure.\n");
@@ -843,12 +846,12 @@ ReadGame(const char *filename)
 			fclose(f);
 			gi.error("Savegame from an other game.so.\n");
 		}
-		else if (strcmp(str_os, OSTYPE))
+		else if (strcmp(str_os, YQ2OSTYPE))
 		{
 			fclose(f);
 			gi.error("Savegame from an other os.\n");
 		}
-		else if (strcmp(str_arch, ARCH))
+		else if (strcmp(str_arch, YQ2ARCH))
 		{
 			fclose(f);
 			gi.error("Savegame from an other architecure.\n");

--- a/zaero/shared/shared.c
+++ b/zaero/shared/shared.c
@@ -6,6 +6,11 @@
  * =======================================================================
  */
 
+#include <ctype.h>
+#ifdef EMSCRIPTEN
+#include <strings.h>
+#endif
+
 #include "../header/shared.h"
 
 #define DEG2RAD(a) (a * M_PI) / 180.0F


### PR DESCRIPTION
At present, the core builds for each Quake II expansion pack fail to run because:

- The base game directory is set incorrectly
- The `qboolean` data type is defined differently (with different data widths) in different files, which means that structs shared between the server and game code end up with different contents - causing memory corruption

This PR fixes the above issues, enabling all three Quake II expansion packs to run. In addition, each core build will fail to load content - and provide an appropriate error notification - if the wrong PAK file is selected (e.g. if the user attempts to load the `rouge` expansion with the `xatrix` core).

Finally, build jobs for all expansion cores have been added to the `gitlab-ci.yml` file.