### PR TITLE
Add 30 fps mode + OpenDingux build target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
 
+  # OpenDingux
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/dingux-mips32.yml'
+
   # tvOS (AppleTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'
@@ -213,6 +217,18 @@ libretro-build-vita:
     - .libretro-vita-static-retroarch-master
     - .core-defs
 
+# OpenDingux
+libretro-build-dingux-mips32:
+  extends:
+    - .libretro-dingux-mips32-make-default
+    - .core-defs
+
+# OpenDingux Beta
+libretro-build-dingux-odbeta-mips32:
+  extends:
+    - .libretro-dingux-odbeta-mips32-make-default
+    - .core-defs
+
 #################################### MISC ##################################
 # Emscripten
 libretro-build-emscripten:
@@ -329,6 +345,18 @@ libretro-build-libnx-aarch64-rogue:
 libretro-build-vita-rogue:
   extends:
     - .libretro-vita-static-retroarch-master
+    - .core-defs-rogue
+
+# OpenDingux
+libretro-build-dingux-mips32-rogue:
+  extends:
+    - .libretro-dingux-mips32-make-default
+    - .core-defs-rogue
+
+# OpenDingux Beta
+libretro-build-dingux-odbeta-mips32-rogue:
+  extends:
+    - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs-rogue
 
 #################################### MISC ##################################
@@ -449,6 +477,18 @@ libretro-build-vita-xatrix:
     - .libretro-vita-static-retroarch-master
     - .core-defs-xatrix
 
+# OpenDingux
+libretro-build-dingux-mips32-xatrix:
+  extends:
+    - .libretro-dingux-mips32-make-default
+    - .core-defs-xatrix
+
+# OpenDingux Beta
+libretro-build-dingux-odbeta-mips32-xatrix:
+  extends:
+    - .libretro-dingux-odbeta-mips32-make-default
+    - .core-defs-xatrix
+
 #################################### MISC ##################################
 # Emscripten
 libretro-build-emscripten-xatrix:
@@ -565,6 +605,18 @@ libretro-build-libnx-aarch64-zaero:
 libretro-build-vita-zaero:
   extends:
     - .libretro-vita-static-retroarch-master
+    - .core-defs-zaero
+
+# OpenDingux
+libretro-build-dingux-mips32-zaero:
+  extends:
+    - .libretro-dingux-mips32-make-default
+    - .core-defs-zaero
+
+# OpenDingux Beta
+libretro-build-dingux-odbeta-mips32-zaero:
+  extends:
+    - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs-zaero
 
 #################################### MISC ##################################

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,15 @@ else ifeq ($(platform), ctr)
     CXXFLAGS += $(CFLAGS) -std=gnu++11
     STATIC_LINKING = 1
     HAVE_OPENGL = 0
+# GCW0
+else ifeq ($(platform), gcw0)
+   TARGET := $(TARGET_NAME)_libretro.so
+   CC = /opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc
+   AR = /opt/gcw0-toolchain/usr/bin/mipsel-linux-ar
+   fpic := -fPIC
+   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/link.T -Wl,--no-undefined
+   CFLAGS += -DDINGUX -D_POSIX_C_SOURCE=199309L -fomit-frame-pointer -march=mips32 -mtune=mips32r2 -mhard-float
+   HAVE_OPENGL = 0
 else
    CC ?= gcc
    TARGET := $(TARGET_NAME)_libretro.dll

--- a/client/cdaudio.h
+++ b/client/cdaudio.h
@@ -23,8 +23,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <stdint.h>
 
-#define AUDIO_SAMPLE_RATE 48000
-#define AUDIO_BUFFER_SIZE  2048
+#define AUDIO_SAMPLE_RATE 44100
+/* Audio buffer must be sufficient for operation
+ * at 30 fps
+ * > (2 * 44100) / 30 = 2490 total samples
+ * > buffer size must be a power of 2
+ * > Nearest power of 2 to 2490 is 4096 */
+#define AUDIO_BUFFER_SIZE  4096
 
 int  CDAudio_Init(void);
 void CDAudio_Shutdown(void);

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -101,7 +101,13 @@ struct retro_core_option_v2_definition option_defs_us[] = {
 #endif
          { NULL, NULL },
       },
+#if defined(DINGUX)
+      "320x240"
+#elif defined(_3DS)
+      "400x240"
+#else
       "960x544"
+#endif
    },
    {
       "vitaquakeii_framerate",
@@ -112,6 +118,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       NULL,
       {
          { "auto", "Auto" },
+         { "30",   "30 fps" },
          { "50",   "50 fps" },
          { "60",   "60 fps" },
          { "72",   "72 fps" },
@@ -132,7 +139,11 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "360",  "360 fps" },
          { NULL, NULL },
       },
+#if defined(DINGUX) || defined(_3DS)
+      "30"
+#else
       "auto"
+#endif
    },
    {
       "vitaquakeii_gamma",


### PR DESCRIPTION
This PR adds a 30 fps mode for use on performance-limited hardware. It also adds a build target for OpenDingux platforms. Tested on an RG350M, the core runs smoothly at 320x240 @ 30 fps.

In addition:

- 30 fps has been set as the default framerate on both OpenDingux and 3DS platforms
- The default resolution for OpenDingux and 3DS platforms has been set to the native device screen resolution
- The audio sample rate has been reduced from 48000 Hz to 44100 Hz. This improves performance, and 48000 Hz was excessive given that the internal SFX have a native rate of 11025 Hz and even the CD audio tracks are only 44100 Hz