### PR TITLE
Makefile fix to enable build for unix-* platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ifeq ($(STATIC_LINKING), 1)
 EXT := a
 endif
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
 	EXT ?= so
    TARGET := $(TARGET_NAME)_libretro.$(EXT)
    fpic := -fPIC
@@ -284,7 +284,7 @@ else ifeq ($(basegame),zaero)
 CFLAGS   += -DZAERO
 endif
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
 CFLAGS += -std=gnu99
 else
 CFLAGS += -std=c99


### PR DESCRIPTION
Compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts). Made platform recognition more flexible.