### PR TITLE
Fix Rogue, Xatrix and Zaero not working if pathname longer than 128 c…

### DIFF
--- a/game/q_shared.h
+++ b/game/q_shared.h
@@ -63,7 +63,13 @@ typedef enum {false, true}	qboolean;
 #define	MAX_TOKEN_CHARS		128		// max length of an individual token
 
 #define	MAX_QPATH			64		// max length of a quake game pathname
-#define	MAX_OSPATH			128		// max length of a filesystem pathname
+
+// max length of a filesystem pathname
+#if defined(_XBOX1) || defined(_3DS) || defined(PSP) || defined(PS2) || defined(GEKKO)|| defined(WIIU) || defined(__PSL1GHT__) || defined(__PS3__)
+#define MAX_OSPATH 512
+#else
+#define MAX_OSPATH 4096
+#endif
 
 //
 // per-level limits


### PR DESCRIPTION
…haracters.  Happens on Xbox One if 'saves' are in default folder.  Thanks to sonninnos for suggestions