### PR TITLE
libnx: add _DEFAULT_SOURCE to fix strdup declaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ else ifeq ($(platform), libnx)
     CFLAGS	:=	 $(DEFINES) -g -O3 \
                  -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec -Wl,--allow-multiple-definition -specs=$(LIBNX)/switch.specs
     CFLAGS += $(INCDIRS) -I$(PORTLIBS)/include/
-    CFLAGS	+=	-D__SWITCH__ -DHAVE_LIBNX -march=armv8-a -mtune=cortex-a57 -mtp=soft
+    CFLAGS	+=	-D__SWITCH__ -DHAVE_LIBNX -D_DEFAULT_SOURCE -march=armv8-a -mtune=cortex-a57 -mtp=soft
     CXXFLAGS := $(ASFLAGS) $(CFLAGS) -fno-rtti -std=gnu++11
     CFLAGS += -std=gnu11
     STATIC_LINKING = 1


### PR DESCRIPTION
https://git.libretro.com/libretro/vitaquake2/-/pipelines/32954

🤖 Generated with [Claude Code](https://claude.com/claude-code)